### PR TITLE
Add strptime to stdlib.datetime

### DIFF
--- a/src/contracting/stdlib/bridge/time.py
+++ b/src/contracting/stdlib/bridge/time.py
@@ -99,7 +99,11 @@ class Datetime:
                    minute=d.minute,
                    second=d.second,
                    microsecond=d.microsecond)
-
+    
+    @classmethod
+    def strptime(cls, date_string, format):
+        d = dt.strptime(date_string, format)
+        return cls._from_datetime(d)
 
 class Timedelta:
     def __init__(self, weeks=0,

--- a/tests/unit/test_datetime.py
+++ b/tests/unit/test_datetime.py
@@ -164,3 +164,28 @@ class TestDatetime(TestCase):
 
         self.assertEqual((d - e), Timedelta(days=365))
 
+
+    def test_datetime_strptime(self):
+        d = dt(2019, 1, 1)
+        self.assertEqual(str(Datetime.strptime(str(d), '%Y-%m-%d %H:%M:%S')), str(d))
+
+    
+    def test_datetime_strptime_invalid_format(self):
+        d = dt(2019, 1, 1)
+        with self.assertRaises(ValueError):
+            Datetime.strptime(str(d), '%Y-%m-%d')
+
+    def test_datetime_strptime_invalid_date(self):
+        with self.assertRaises(ValueError):
+            Datetime.strptime('2019-02-30 12:00:00', '%Y-%m-%d %H:%M:%S')
+
+
+    def test_datetime_strptime_invalid_date_format(self):
+        with self.assertRaises(ValueError):
+            Datetime.strptime('2019-02-30 12:00:00', '%Y-%m-%d %H:%M:%S')
+
+
+    def test_datetime_returns_correct_datetime_cls(self):
+        d = dt(2019, 1, 1)
+        self.assertEqual(Datetime.strptime(str(d), '%Y-%m-%d %H:%M:%S'), Datetime(2019, 1, 1))
+


### PR DESCRIPTION
this is needed for creating Datetime objects from strings. Specifically for XSC003