### PR TITLE
storage-home is now an optional arg for classes Driver & ContractingClient

### DIFF
--- a/src/contracting/client.py
+++ b/src/contracting/client.py
@@ -192,12 +192,13 @@ class ContractingClient:
             self,
             signer='sys',
             submission_filename=os.path.join(os.path.dirname(__file__), 'contracts/submission.s.py'),
-            driver=Driver(),
+            storage_home=constants.STORAGE_HOME,
+            driver:Driver=None,
             metering=False,
             compiler=ContractingCompiler(),
-            environment={}
+            environment={},
     ):
-
+        driver = driver if driver is not None else Driver(storage_home=storage_home)
         self.executor = Executor(metering=metering, driver=driver)
         self.raw_driver = driver
         self.signer = signer

--- a/src/contracting/constants.py
+++ b/src/contracting/constants.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 RECURSION_LIMIT = 1024
 
 DELIMITER = ':'
@@ -25,3 +27,5 @@ BLOCK_NUM_DEFAULT = -1
 FILENAME_LEN_MAX = 255
 
 DEFAULT_STAMPS = 1000000
+
+STORAGE_HOME = Path().home().joinpath(".cometbft/xian")

--- a/src/contracting/storage/driver.py
+++ b/src/contracting/storage/driver.py
@@ -16,7 +16,6 @@ import shutil
 FILE_EXT = ".d"
 HASH_EXT = ".x"
 
-STORAGE_HOME = Path().home().joinpath(".cometbft/xian")
 DELIMITER = "."
 HASH_DEPTH_DELIMITER = ":"
 
@@ -30,14 +29,14 @@ DEVELOPER_KEY = "__developer__"
 
 
 class Driver:
-    def __init__(self, bypass_cache=False):
+    def __init__(self, bypass_cache=False, storage_home=constants.STORAGE_HOME):
         self.pending_deltas = {}
         self.pending_writes = {}
         self.pending_reads = {}
         self.cache = TTLCache(maxsize=1000, ttl=6*3600)
         self.bypass_cache = bypass_cache
-        self.contract_state = STORAGE_HOME.joinpath("contract_state")
-        self.run_state = STORAGE_HOME.joinpath("run_state")
+        self.contract_state = storage_home.joinpath("contract_state")
+        self.run_state = storage_home.joinpath("run_state")
         self.__build_directories()
 
     def __build_directories(self):


### PR DESCRIPTION

## Description

This is a requisite for proper isolation of a testing environment for `xian-core`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would require a resync of blockchain state)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested this change in my development environment.
- [x] I have added tests to prove that this change works
- [x] All existing tests pass after this change
- [ ] I have added / updated documentation related to this change