### PR TITLE
Randomx stamp costs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,10 +47,11 @@ setup(
         "pycodestyle==2.10.0",
         "autopep8==1.5.7",
         "iso8601",
-        "h5py",
         "cachetools",
         "loguru",
-        "pynacl"
+        "pynacl",
+        "randomx",
+        "h5py",
     ],
     url="https://github.com/xian-network/contracting",
     author="Xian",

--- a/src/contracting/execution/executor.py
+++ b/src/contracting/execution/executor.py
@@ -153,7 +153,7 @@ class Executor:
         stamps_used = runtime.rt.tracer.get_stamp_used()
 
         stamps_used = stamps_used // 1000
-        stamps_used += 1
+        stamps_used += 5
 
         if stamps_used > stamps:
             stamps_used = stamps

--- a/src/contracting/stdlib/bridge/crypto.py
+++ b/src/contracting/stdlib/bridge/crypto.py
@@ -1,4 +1,5 @@
 from types import ModuleType
+import randomx
 import nacl
 
 
@@ -27,9 +28,24 @@ def key_is_valid(key: str):
     return True
 
 
+def randomx_hash(key: str, message: str):
+    try :
+        key_bytes = bytes.fromhex(key)
+    except ValueError:
+        key_bytes = key.encode()
+    try :
+        message_bytes = bytes.fromhex(message)
+    except ValueError:
+        message_bytes = message.encode()
+    # breakpoint()
+    vm = randomx.RandomX(key_bytes, full_mem=True, secure=False, large_pages=True)
+    return vm(message_bytes)
+
+
 crypto_module = ModuleType('crypto')
 crypto_module.verify = verify
 crypto_module.key_is_valid = key_is_valid
+crypto_module.randomx_hash = randomx_hash
 
 exports = {
     'crypto': crypto_module

--- a/src/contracting/stdlib/bridge/crypto.py
+++ b/src/contracting/stdlib/bridge/crypto.py
@@ -29,17 +29,16 @@ def key_is_valid(key: str):
 
 
 def randomx_hash(key: str, message: str):
-    try :
+    try:
         key_bytes = bytes.fromhex(key)
     except ValueError:
         key_bytes = key.encode()
-    try :
+    try:
         message_bytes = bytes.fromhex(message)
     except ValueError:
         message_bytes = message.encode()
-    # breakpoint()
-    vm = randomx.RandomX(key_bytes, full_mem=True, secure=False, large_pages=True)
-    return vm(message_bytes)
+    vm = randomx.RandomX(key_bytes, full_mem=False, secure=False, large_pages=False)
+    return vm(message_bytes).hex()
 
 
 crypto_module = ModuleType('crypto')

--- a/tests/unit/test_crypto.py
+++ b/tests/unit/test_crypto.py
@@ -1,0 +1,31 @@
+from unittest import TestCase
+from contracting.stdlib.bridge.crypto import randomx_hash
+import binascii
+
+class TestCrypto(TestCase):
+
+    def test_randomx_hash(self):
+
+        expected = [
+            "a86260b7bf2c35910177ae47bad732b415d977d865a3d64c12e06a3f012b2ee7",
+            "aa820e6869feccba3e58790437de698bafc2eeaf1a135c928d1b59b2473fb74d",
+            "776a5cb55b212950c55911a99b1fc35f36e937e2b1ff6cdf6aff27e0bb36f637",
+            "f2f1ae1030f53b743da7c13f9c2f85db6991f0617e360663c815158d72897ec4",
+            "0ea23341e489a9720ff4bfbd0391338918a295d46416b87dfe8a785cce9eb51d",
+        ]
+        
+        seed_hash = binascii.unhexlify('63eceef7919087068ac5d1b7faffa23fc90a58ad0ca89ecb224a2ef7ba282d48')
+
+        for x in range(5):
+            m = "Hello RandomX {}".format(x)
+            print("Hashing: {}".format(m))
+            if x == 0:
+                print("(first takes a while, please wait)")
+            # h = 1 + x
+            # bh = pyrx.get_rx_hash(m, seed_hash, h)
+            # hh = binascii.hexlify(bh).decode()
+            # print("Result: {}".format(hh))
+            # assert hh == expected[x]
+            breakpoint()
+            res = randomx_hash('63eceef7919087068ac5d1b7faffa23fc90a58ad0ca89ecb224a2ef7ba282d48', "hello")
+            # breakpoint()

--- a/tests/unit/test_crypto.py
+++ b/tests/unit/test_crypto.py
@@ -1,31 +1,53 @@
 from unittest import TestCase
 from contracting.stdlib.bridge.crypto import randomx_hash
+import random
+import string
 import binascii
 
 class TestCrypto(TestCase):
 
+    def random_string(self, length):
+        return ''.join(random.choices(string.ascii_letters + string.digits, k=length))
+
+    def random_hex_string(self, length):
+        return ''.join(random.choices('0123456789abcdef', k=length))
+
     def test_randomx_hash(self):
 
         expected = [
-            "a86260b7bf2c35910177ae47bad732b415d977d865a3d64c12e06a3f012b2ee7",
-            "aa820e6869feccba3e58790437de698bafc2eeaf1a135c928d1b59b2473fb74d",
-            "776a5cb55b212950c55911a99b1fc35f36e937e2b1ff6cdf6aff27e0bb36f637",
-            "f2f1ae1030f53b743da7c13f9c2f85db6991f0617e360663c815158d72897ec4",
-            "0ea23341e489a9720ff4bfbd0391338918a295d46416b87dfe8a785cce9eb51d",
+            "7ba1fefe2ac793fcdea6436b8fb0cbc3254e2a289027896d9a9d0a747759897f",
+            "d2d88402817eb5d37be0e4b80ee3670e596ce1303c22c87c2d576b63e4c3283f",
+            "4d9f9aa4aa4f27eac09f700a52047b76d1168936fa01e352aeeb172c1eb56005",
+            "fb8e209d45012ef72583bd846ba6c8dfa86e59f3a59c769f7ea3f55bbb9b9f9b",
+            "7798a6d5cb45fe0aa79dae48a50138e52b1bf0c0a9fd7664306ccffbde660612",
         ]
-        
-        seed_hash = binascii.unhexlify('63eceef7919087068ac5d1b7faffa23fc90a58ad0ca89ecb224a2ef7ba282d48')
 
         for x in range(5):
             m = "Hello RandomX {}".format(x)
             print("Hashing: {}".format(m))
-            if x == 0:
-                print("(first takes a while, please wait)")
-            # h = 1 + x
-            # bh = pyrx.get_rx_hash(m, seed_hash, h)
-            # hh = binascii.hexlify(bh).decode()
-            # print("Result: {}".format(hh))
-            # assert hh == expected[x]
-            breakpoint()
-            res = randomx_hash('63eceef7919087068ac5d1b7faffa23fc90a58ad0ca89ecb224a2ef7ba282d48', "hello")
-            # breakpoint()
+            res = randomx_hash('63eceef7919087068ac5d1b7faffa23fc90a58ad0ca89ecb224a2ef7ba282d48', m + str(x))
+            self.assertEqual(res, expected[x])
+            self.assertEqual(str(type(res)), "<class 'str'>")
+
+    def test_randomx_hash_invalid_hex_key(self):
+        key = 'invalidhexkey'
+        message = '4d657373616765'
+        res = randomx_hash(key, message)
+        self.assertEqual(res, 'f2649fde52dc7a395e9be604116ff46299130d4e57d745331f23c5538c125ef5')
+
+    def test_randomx_hash_empty_key(self):
+        key = ''
+        message = '4d657373616765'
+        res = randomx_hash(key, message)
+        self.assertEqual(res, "b5b573af85a6880b3e0c391d22e0700d8cd375948386da31d0c534bd72c6e30f")
+
+    def test_randomx_hash_fuzz_mixed_input(self):
+        for _ in range(100):
+            key = self.random_string(random.randint(1, 128))
+            message = self.random_string(random.randint(1, 128))
+            try:
+                result = randomx_hash(key, message)
+                self.assertIsInstance(result, str)
+                self.assertEqual(len(result), 64)  # Assuming the hash length is 64 hex characters
+            except Exception as e:
+                self.fail(f"randomx_hash raised an exception with mixed input: {e}")


### PR DESCRIPTION
## Description

- added randomx python C binding library
- added new method to `crypto` stdlib, `randomx_hash`
- changed minimum stamp cost for all transactions (1 -> 5)
- modified tracer.c to add 1000 stamps for calls of the crypto.randomx_hash module.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would require a resync of blockchain state)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested this change in my development environment.
- [ ] I have added tests to prove that this change works
- [ ] All existing tests pass after this change
- [ ] I have added / updated documentation related to this change