### PR TITLE
Fix for unexpected argument in keys()

### DIFF
--- a/src/contracting/storage/driver.py
+++ b/src/contracting/storage/driver.py
@@ -144,7 +144,7 @@ class Driver:
         try:
             filename, _ = self.__parse_key(prefix)
         except Exception:
-            return self.keys(prefix=prefix, length=length)
+            return self.keys(prefix=prefix)
 
         if not self.is_file(filename=filename):
             return []


### PR DESCRIPTION
## Description

Fix unexpected argument - function `keys()` doesn't accept a `length` parameter

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)