### PR TITLE
Allow setting `None` when using `default_value`

### DIFF
--- a/src/contracting/storage/orm.py
+++ b/src/contracting/storage/orm.py
@@ -16,13 +16,11 @@ class Datum:
 class Variable(Datum):
     def __init__(self, contract, name, driver: Driver = driver, t=None, default_value=None):
         self._type = None
-
         if isinstance(t, type):
             self._type = t
-
-        self._default_value = default_value
-
         super().__init__(contract, name, driver=driver)
+        # Set initial value to default
+        self._driver.set(self._key, default_value, True)
 
     def set(self, value):
         if self._type is not None and value is not None:
@@ -30,14 +28,10 @@ class Variable(Datum):
               f'Wrong type passed to variable! '
               f'Expected {self._type}, got {type(value)}.'
             )
-
         self._driver.set(self._key, value, True)
 
     def get(self):
-        value = self._driver.get(self._key)
-        if value is None:
-            return self._default_value
-        return value
+        return self._driver.get(self._key)
 
 class Hash(Datum):
     def __init__(self, contract, name, driver: Driver = driver, default_value=None):


### PR DESCRIPTION
## Description

This PR modifies the Variable class to properly handle default values. When a default value is provided during initialization, it is immediately written to storage. This ensures that get() returns the default value before any explicit set() calls, while still allowing None to be explicitly set and retrieved.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested this change in my development environment.
- [ ] I have added tests to prove that this change works
- [ ] All existing tests pass after this change
- [ ] I have added / updated documentation related to this change