### PR TITLE
Fix float literal conversion in function parameter defaults

### DIFF
--- a/src/contracting/compilation/compiler.py
+++ b/src/contracting/compilation/compiler.py
@@ -63,6 +63,14 @@ class ContractingCompiler(ast.NodeTransformer):
         code = astor.to_source(tree)
         return code
 
+    def _convert_float_to_decimal_call(self, float_value):
+        """Helper method to create a decimal() call from a float value."""
+        return ast.Call(
+            func=ast.Name(id='decimal', ctx=ast.Load()),
+            args=[ast.Str(str(float_value))],
+            keywords=[]
+        )
+
     def visit_FunctionDef(self, node):
 
         # Presumes all decorators are valid, as caught by linter.
@@ -89,6 +97,33 @@ class ContractingCompiler(ast.NodeTransformer):
         else:
             self.private_names.add(node.name)
             node.name = self.privatize(node.name)
+
+        # Handle float literals in function parameter defaults
+        if node.args.defaults:
+            new_defaults = []
+            for default in node.args.defaults:
+                # Handle both ast.Num (Python < 3.8) and ast.Constant (Python 3.8+)
+                if isinstance(default, ast.Num) and isinstance(default.n, float):
+                    new_defaults.append(self._convert_float_to_decimal_call(default.n))
+                elif isinstance(default, ast.Constant) and isinstance(default.value, float):
+                    new_defaults.append(self._convert_float_to_decimal_call(default.value))
+                else:
+                    new_defaults.append(default)
+            node.args.defaults = new_defaults
+
+        # Handle float literals in keyword-only defaults (Python 3+)
+        if hasattr(node.args, 'kw_defaults') and node.args.kw_defaults:
+            new_kw_defaults = []
+            for default in node.args.kw_defaults:
+                if default is None:
+                    new_kw_defaults.append(default)
+                elif isinstance(default, ast.Num) and isinstance(default.n, float):
+                    new_kw_defaults.append(self._convert_float_to_decimal_call(default.n))
+                elif isinstance(default, ast.Constant) and isinstance(default.value, float):
+                    new_kw_defaults.append(self._convert_float_to_decimal_call(default.value))
+                else:
+                    new_kw_defaults.append(default)
+            node.args.kw_defaults = new_kw_defaults
 
         self.generic_visit(node)
 
@@ -119,4 +154,11 @@ class ContractingCompiler(ast.NodeTransformer):
         if isinstance(node.n, float):
             return ast.Call(func=ast.Name(id='decimal', ctx=ast.Load()),
                             args=[ast.Str(str(node.n))], keywords=[])
+        return node
+
+    def visit_Constant(self, node):
+        # Python 3.8+ uses ast.Constant instead of ast.Num for literals
+        if isinstance(node.value, float):
+            return ast.Call(func=ast.Name(id='decimal', ctx=ast.Load()),
+                            args=[ast.Str(str(node.value))], keywords=[])
         return node


### PR DESCRIPTION
## Fix float literal conversion in function parameter defaults

### Problem
Function parameters with float default values caused `TypeError: '<=' not supported between instances of 'decimal.Decimal' and 'NoneType'` when used in comparisons within contract functions.

Example failing code:
```python
@export
def create_pool(penalty_rate: float = 0.1):
    assert penalty_rate >= 0.0 and penalty_rate <= 1.0, "Invalid rate"
```

### Root Cause
The `ContractingCompiler` only converted float literals in expressions (`visit_Num`), but ignored float literals in function parameter defaults. This created inconsistent types:
- `penalty_rate` parameter received a raw `float` (0.1) 
- Comparison literals `0.0` and `1.0` were converted to `ContractingDecimal`
- Type mismatch caused comparison failures

### Solution
Enhanced `visit_FunctionDef` to convert float literals in:
- Regular parameter defaults (`args.defaults`)
- Keyword-only parameter defaults (`args.kw_defaults`)

Added `visit_Constant` for Python 3.8+ compatibility (which uses `ast.Constant` instead of `ast.Num`).

### Impact
- ✅ Fixes type consistency across all float usage
- ✅ Maintains backward compatibility
- ✅ Supports Python 3.8+
- ✅ No breaking changes to existing contracts

All float literals now consistently convert to `ContractingDecimal`, preventing type mismatch errors in contract execution.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would require a resync of blockchain state)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have tested this change in my development environment.
- [ ] I have added tests to prove that this change works
- [ ] All existing tests pass after this change
- [ ] I have added / updated documentation related to this change