### PR TITLE
Fix TypeError in AbstractContract._abstract_function_call when return_full_output=True

### DIFF
--- a/src/contracting/client.py
+++ b/src/contracting/client.py
@@ -180,8 +180,8 @@ class AbstractContract:
         if executor.production:
             executor.sandbox.terminate()
 
-        if output['status_code'] == 1:
-            raise output['result'] if not return_full_output else output
+        if output['status_code'] == 1 and not return_full_output:
+            raise output['result']
         return output['result'] if not return_full_output else output
 
 


### PR DESCRIPTION
# Fix TypeError in AbstractContract._abstract_function_call when return_full_output=True

## Problem

When calling contract methods with `return_full_output=True` and the contract execution results in an error (status_code == 1), the `_abstract_function_call` method in `AbstractContract` throws a `TypeError: exceptions must derive from BaseException` instead of returning the full output dictionary as expected.

## Root Cause

The bug is in this line in `client.py`:

```python
if output['status_code'] == 1:
    raise output['result'] if not return_full_output else output
```

When `return_full_output=True`, the ternary operator evaluates to `raise output`, where `output` is a dictionary. Python's `raise` statement requires an exception object, not a dictionary, causing the TypeError.

## Reproduction

This minimal test case reproduces the issue:

```python
import unittest
from contracting.client import ContractingClient

class TestBug(unittest.TestCase):
    def setUp(self):
        self.client = ContractingClient()
        self.client.flush()
        
        # Submit a contract that will fail
        contract_code = '''
@export
def failing_function():
    assert False, "This will fail"
'''
        self.client.submit(contract_code, name='test_contract')
        self.contract = self.client.get_contract('test_contract')
    
    def test_return_full_output_with_error(self):
        """This test will fail with TypeError before the fix"""
        try:
            result = self.contract.failing_function(return_full_output=True)
            # Should reach here and get a dict with status_code == 1
            self.assertEqual(result['status_code'], 1)
        except TypeError as e:
            self.fail(f"Should not raise TypeError: {e}")
```

**Expected behavior**: Returns a dictionary with `status_code == 1` and error details  
**Actual behavior**: Raises `TypeError: exceptions must derive from BaseException`

## Solution

Split the error handling logic to handle the two cases separately:

```python
# Fixed version
if output['status_code'] == 1 and not return_full_output:
    raise output['result']
return output['result'] if not return_full_output else output
```

This ensures that:
- When `return_full_output=False`: Exceptions are raised as before (preserves existing behavior)
- When `return_full_output=True`: Always returns the full output dictionary, even for errors

## Type
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would require a resync of blockchain state)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have tested this change in my development environment.
- [ ] I have added tests to prove that this change works
- [ ] All existing tests pass after this change
- [ ] I have added / updated documentation related to this change