### PR TITLE
Restore driver state after failed executions

### DIFF
--- a/src/contracting/execution/executor.py
+++ b/src/contracting/execution/executor.py
@@ -10,6 +10,27 @@ import importlib
 import decimal
 
 
+def _snapshot_driver_state(driver: Driver):
+    return {
+        'pending_writes': deepcopy(driver.pending_writes),
+        'pending_reads': deepcopy(driver.pending_reads),
+        'pending_deltas': deepcopy(driver.pending_deltas),
+        'transaction_writes': deepcopy(driver.transaction_writes),
+        'log_events': deepcopy(driver.log_events),
+        'cache_items': [(k, driver._clone_value(v)) for k, v in driver.cache.items()],
+    }
+
+
+def _restore_driver_state(driver: Driver, snapshot):
+    driver.pending_writes = snapshot['pending_writes']
+    driver.pending_reads = snapshot['pending_reads']
+    driver.pending_deltas = snapshot['pending_deltas']
+    driver.transaction_writes = snapshot['transaction_writes']
+    driver.log_events = snapshot['log_events']
+    driver.cache.clear()
+    driver.cache.update(snapshot['cache_items'])
+
+
 class Executor:
     def __init__(self,
                  production=False,
@@ -48,7 +69,6 @@ class Executor:
                 stamp_cost=constants.STAMPS_PER_TAU,
                 metering=None) -> dict:
 
-        current_driver_pending_writes = deepcopy(self.driver.pending_writes)
         self.driver.clear_transaction_writes()
         self.driver.clear_events()
 
@@ -62,8 +82,11 @@ class Executor:
 
         if driver:
             runtime.rt.env.update({'__Driver': driver})
-        else:
-            driver = runtime.rt.env.get('__Driver')
+            driver.clear_transaction_writes()
+            driver.clear_events()
+        driver = runtime.rt.env.get('__Driver')
+
+        driver_state_snapshot = _snapshot_driver_state(driver)
 
         install_database_loader(driver=driver)
 
@@ -138,7 +161,7 @@ class Executor:
             result = e
             status_code = 1
             # Revert the writes if the transaction fails
-            driver.pending_writes = current_driver_pending_writes
+            _restore_driver_state(driver, driver_state_snapshot)
             transaction_writes = {}
             events = []
             if auto_commit:

--- a/src/contracting/storage/driver.py
+++ b/src/contracting/storage/driver.py
@@ -8,6 +8,8 @@ from cachetools import TTLCache
 from contracting import constants
 from contracting.storage import hdf5
 
+from copy import deepcopy
+
 import marshal
 import decimal
 import os
@@ -40,6 +42,17 @@ class Driver:
         self.contract_state = storage_home.joinpath("contract_state")
         self.run_state = storage_home.joinpath("run_state")
         self.__build_directories()
+
+    @staticmethod
+    def _clone_value(value):
+        if value is None:
+            return None
+
+        # Immutable primitives can be returned directly.
+        if isinstance(value, (str, bytes, int, bool, ContractingDecimal, decimal.Decimal)):
+            return value
+
+        return deepcopy(value)
 
     def __build_directories(self):
         self.contract_state.mkdir(exist_ok=True, parents=True)
@@ -82,10 +95,10 @@ class Driver:
         # Parse the key to get the filename and group
         value = self.find(key)
         if save and self.pending_reads.get(key) is None:
-            self.pending_reads[key] = value
+            self.pending_reads[key] = self._clone_value(value)
         # if value is not None:
         #     rt.deduct_read(*encode_kv(key, value))
-        return value
+        return self._clone_value(value)
 
 
     def set(self, key, value, is_txn_write=False):
@@ -94,9 +107,11 @@ class Driver:
             self.get(key)
         if type(value) in [decimal.Decimal, float]:
             value = ContractingDecimal(str(value))
-        self.pending_writes[key] = value
+
+        cloned_value = self._clone_value(value)
+        self.pending_writes[key] = cloned_value
         if is_txn_write:
-            self.transaction_writes[key] = value
+            self.transaction_writes[key] = self._clone_value(cloned_value)
 
 
     def find(self, key: str):
@@ -179,13 +194,13 @@ class Driver:
         # Collect pending writes with matching prefix
         for k, v in self.pending_writes.items():
             if k.startswith(prefix) and v is not None:
-                _items[k] = v
+                _items[k] = self._clone_value(v)
                 keys.add(k)
 
         # Collect cache items with matching prefix
         for k, v in self.cache.items():
             if k.startswith(prefix) and v is not None:
-                _items[k] = v
+                _items[k] = self._clone_value(v)
                 keys.add(k)
 
         # Collect keys from the disk
@@ -202,7 +217,6 @@ class Driver:
         return list(self.items(prefix).keys())
 
     def values(self, prefix=""):
-        l = list(self.items(prefix).values())
         return list(self.items(prefix).values())
 
     def make_key(self, contract, variable, args=[]):
@@ -340,7 +354,7 @@ class Driver:
                     break
                 to_delete.append(_nanos)
                 for key, delta in _deltas['writes'].items():
-                    self.cache[key] = delta[0]  # Restoring the value before the write
+                    self.cache[key] = self._clone_value(delta[0])  # Restoring the value before the write
 
             for _nanos in to_delete:
                 self.pending_deltas.pop(_nanos, None)
@@ -370,11 +384,17 @@ class Driver:
         deltas = {}
         for k, v in self.pending_writes.items():
             current = self.pending_reads.get(k)
-            deltas[k] = (current, v)
+            deltas[k] = (
+                self._clone_value(current),
+                self._clone_value(v)
+            )
 
-            self.cache[k] = v
+            self.cache[k] = self._clone_value(v)
 
-        self.pending_deltas[nanos] = {"writes": deltas, "reads": self.pending_reads}
+        self.pending_deltas[nanos] = {
+            "writes": deltas,
+            "reads": deepcopy(self.pending_reads)
+        }
 
         # Clear the top cache
         self.pending_reads = {}

--- a/src/contracting/storage/orm.py
+++ b/src/contracting/storage/orm.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 from contracting.storage.driver import Driver
 from contracting.execution.runtime import rt
 from contracting import constants
@@ -58,7 +60,10 @@ class Hash(Datum):
         if type(value) == float or type(value) == ContractingDecimal:
             return ContractingDecimal(str(value))
 
-        return value
+        if value is None:
+            return None
+
+        return deepcopy(value)
 
     def _validate_key(self, key):
         if isinstance(key, tuple):

--- a/tests/integration/test_contracts/otc_failure.s.py
+++ b/tests/integration/test_contracts/otc_failure.s.py
@@ -1,0 +1,28 @@
+reentrancy = Variable(default_value=False)
+otc_listing = Hash()
+
+@construct
+def seed():
+    otc_listing['listing'] = {'status': 'OPEN'}
+
+@export
+def get_listing():
+    return otc_listing['listing']
+
+@export
+def guard_active():
+    return reentrancy.get()
+
+@export
+def take():
+    assert not reentrancy.get(), 'Contract is busy'
+    reentrancy.set(True)
+
+    listing = otc_listing['listing']
+    assert listing is not None, 'Missing listing'
+    assert listing['status'] == 'OPEN', 'Offer not available'
+
+    listing['status'] = 'EXECUTED'
+    otc_listing['listing'] = listing
+
+    assert False, 'Not enough coins to send.'

--- a/tests/integration/test_failed_cross_contract_revert.py
+++ b/tests/integration/test_failed_cross_contract_revert.py
@@ -1,0 +1,69 @@
+import os
+from unittest import TestCase
+
+import contracting
+
+from contracting.execution.executor import Executor
+from contracting.storage.driver import Driver
+
+
+def submission_kwargs_for_file(path):
+    with open(path) as file:
+        code = file.read()
+    name = os.path.basename(path).split('.')[0]
+    return {
+        'name': f'con_{name}',
+        'code': code,
+    }
+
+
+class TestFailedCrossContractRevert(TestCase):
+    def setUp(self):
+        self.driver = Driver()
+        self.driver.flush_full()
+
+        with open(contracting.__path__[0] + '/contracts/submission.s.py') as f:
+            contract = f.read()
+
+        self.driver.set_contract(name='submission', code=contract)
+        self.driver.commit()
+
+        self.executor = Executor(metering=False)
+
+        contracts_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_contracts')
+        self.market_path = os.path.join(contracts_dir, 'otc_failure.s.py')
+
+        self.executor.execute(
+            sender='stu',
+            contract_name='submission',
+            function_name='submit_contract',
+            kwargs=submission_kwargs_for_file(self.market_path),
+            auto_commit=True,
+        )
+
+    def tearDown(self):
+        self.executor.bypass_privates = False
+        self.driver.flush_full()
+
+    def test_reverts_all_state_on_failed_cross_contract_call(self):
+        result = self.executor.execute('bob', 'con_otc_failure', 'take', kwargs={})
+
+        self.assertEqual(result['status_code'], 1)
+        self.assertIsInstance(result['result'], AssertionError)
+        self.assertIn('Not enough coins to send.', result['result'].args[0])
+        self.assertNotIn(
+            'con_otc_failure.otc_listing:listing',
+            self.executor.driver.pending_reads,
+            'Failed transaction should not leave mutated entries cached in pending_reads.',
+        )
+
+        listing = self.executor.execute('bob', 'con_otc_failure', 'get_listing', kwargs={})
+        self.assertEqual(listing['result']['status'], 'OPEN')
+
+        guard_state = self.executor.execute('bob', 'con_otc_failure', 'guard_active', kwargs={})
+        self.assertFalse(guard_state['result'])
+
+        second_attempt = self.executor.execute('bob', 'con_otc_failure', 'take', kwargs={})
+        self.assertEqual(second_attempt['status_code'], 1)
+        self.assertIsInstance(second_attempt['result'], AssertionError)
+        self.assertIn('Not enough coins to send.', second_attempt['result'].args[0])


### PR DESCRIPTION
## Summary
- snapshot the storage driver state before contract execution and restore it on exceptions so caches and pending reads stay deterministic
- add a regression contract and integration test to ensure failed executions leave offers OPEN and the reentrancy guard released

## Testing
- PYTHONPATH=src pytest tests/integration/test_failed_cross_contract_revert.py -q

------
https://chatgpt.com/codex/tasks/task_e_68df8d9c1d2c83209147a1ddf235045f