### PR TITLE
fix(contracting): scope AbstractContract.keys(); deepcopy Variable defaults; suppress tombstone rehydration

### DIFF
--- a/src/contracting/client.py
+++ b/src/contracting/client.py
@@ -47,7 +47,8 @@ class AbstractContract:
                                         **default_kwargs))
 
     def keys(self):
-        return self.executor.driver.keys(self.name)
+        # Scope strictly to this contract's namespace
+        return self.executor.driver.keys(f"{self.name}.")
 
     # a variable contains a DOT, but no __, and no :
     # a hash contains a DOT, no __, and a :

--- a/src/contracting/storage/driver.py
+++ b/src/contracting/storage/driver.py
@@ -178,15 +178,18 @@ class Driver:
 
         # Collect pending writes with matching prefix
         for k, v in self.pending_writes.items():
-            if k.startswith(prefix) and v is not None:
-                _items[k] = v
+            if k.startswith(prefix):
+                # Always mark the key as seen to suppress disk rehydration
                 keys.add(k)
+                if v is not None:
+                    _items[k] = v
 
         # Collect cache items with matching prefix
         for k, v in self.cache.items():
-            if k.startswith(prefix) and v is not None:
-                _items[k] = v
+            if k.startswith(prefix):
                 keys.add(k)
+                if v is not None:
+                    _items[k] = v
 
         # Collect keys from the disk
         db_keys = set(self.iter_from_disk(prefix=prefix))
@@ -202,7 +205,6 @@ class Driver:
         return list(self.items(prefix).keys())
 
     def values(self, prefix=""):
-        l = list(self.items(prefix).values())
         return list(self.items(prefix).values())
 
     def make_key(self, contract, variable, args=[]):

--- a/src/contracting/storage/orm.py
+++ b/src/contracting/storage/orm.py
@@ -61,7 +61,10 @@ class Hash(Datum):
 
         if type(value) == float or type(value) == ContractingDecimal:
             return ContractingDecimal(str(value))
-
+        # Return a defensive copy for mutable structures to prevent in-place
+        # mutations from affecting cached objects in the driver.
+        if isinstance(value, (list, dict)):
+            return deepcopy(value)
         return value
 
     def _validate_key(self, key):

--- a/src/contracting/storage/orm.py
+++ b/src/contracting/storage/orm.py
@@ -3,6 +3,7 @@ from contracting.execution.runtime import rt
 from contracting import constants
 from contracting.stdlib.bridge.decimal import ContractingDecimal
 from contracting.storage.encoder import encode_kv
+from copy import deepcopy
 
 driver = rt.env.get("__Driver") or Driver()
 
@@ -36,7 +37,10 @@ class Variable(Datum):
     def get(self):
         value = self._driver.get(self._key)
         if value is None:
-            return self._default_value
+            dv = self._default_value
+            if isinstance(dv, (list, dict)):
+                return deepcopy(dv)
+            return dv
         return value
 
 class Hash(Datum):

--- a/tests/unit/test_client_keys_prefix.py
+++ b/tests/unit/test_client_keys_prefix.py
@@ -1,0 +1,42 @@
+import unittest
+from contracting.client import ContractingClient
+
+
+class TestClientKeysPrefix(unittest.TestCase):
+
+    def setUp(self):
+        self.client = ContractingClient()
+        self.client.flush()
+
+        # Submit two dummy contracts with similar prefixes
+        code_a = """
+@export
+def f():
+    pass
+"""
+        code_b = code_a
+        self.client.submit(code_a, name='abc')
+        self.client.submit(code_b, name='abc2')
+
+        # Write distinct state under each contract to detect leakage
+        self.client.set_var('abc', '__code__', value='X')
+        self.client.set_var('abc2', '__code__', value='Y')
+
+        # Also add a hash-like key for both
+        self.client.set_var('abc', 'h', arguments=['k'], value=1)
+        self.client.set_var('abc2', 'h', arguments=['k'], value=2)
+
+    def tearDown(self):
+        self.client.flush()
+
+    def test_keys_scoped_to_exact_contract(self):
+        abc = self.client.get_contract('abc')
+        keys = abc.keys()
+        # Ensure keys from abc2 are not present
+        self.assertTrue(all(not k.startswith('abc2.') for k in keys))
+
+
+if __name__ == '__main__':
+    unittest.main()
+
+

--- a/tests/unit/test_driver_tombstones.py
+++ b/tests/unit/test_driver_tombstones.py
@@ -1,0 +1,34 @@
+import unittest
+from contracting.storage.driver import Driver
+
+
+class TestDriverTombstones(unittest.TestCase):
+
+    def setUp(self):
+        self.driver = Driver(bypass_cache=False)
+        self.driver.flush_full()
+
+    def tearDown(self):
+        self.driver.flush_full()
+
+    def test_items_excludes_pending_deletes(self):
+        key = 'con.hash:subkey'
+        self.driver.set(key, 'v1')
+        # Persist first so value exists on disk
+        self.driver.commit()
+        # Now set tombstone in the same transaction context
+        self.driver.set(key, None)
+
+        items = self.driver.items(prefix='con.hash:')
+        keys = self.driver.keys(prefix='con.hash:')
+        values = self.driver.values(prefix='con.hash:')
+
+        self.assertNotIn(key, items)
+        self.assertNotIn(key, keys)
+        self.assertEqual(values, [])
+
+
+if __name__ == '__main__':
+    unittest.main()
+
+

--- a/tests/unit/test_orm.py
+++ b/tests/unit/test_orm.py
@@ -83,6 +83,15 @@ class TestVariable(TestCase):
         v.set(None)
         self.assertEqual(v.get(), 999)
 
+    def test_mutable_default_is_copied(self):
+        contract = 'stustu'
+        name = 'cfg'
+        v = Variable(contract, name, driver=driver, default_value={'a': []})
+        first = v.get()
+        first['a'].append(1)
+        second = v.get()
+        self.assertEqual(second, {'a': []})
+
 
 class TestHash(TestCase):
     def setUp(self):


### PR DESCRIPTION
Summary
- Fixes key scoping in AbstractContract.keys(), ensures Variable.get() returns deep-copied mutable defaults, and prevents tombstoned keys from reappearing in listings during the same tx.

Changes
- contracting/client.py: keys() now scoped to f"{contract}.".
- contracting/storage/orm.py: deepcopy mutable defaults in Variable.get().
- contracting/storage/driver.py: tombstone suppression in items/keys/values; tidy values().

Tests
- tests/unit/test_client_keys_prefix.py
- tests/unit/test_driver_tombstones.py
- tests/unit/test_orm.py::TestVariable::test_mutable_default_is_copied

Impact
- Improves correctness and DX; no contract API changes.