### PR TITLE
Add deterministic crypto tests and metering coverage

### DIFF
--- a/tests/integration/test_contracts/crypto_usage.s.py
+++ b/tests/integration/test_contracts/crypto_usage.s.py
@@ -1,0 +1,10 @@
+@export
+def commit(value: int, blinding: str):
+    # Mirror the stdlib bridge usage within a contract context.
+    return crypto.pedersen_commit(str(value), blinding)
+
+
+@export
+def verify_range(commitment: str, bit_commitments: list, bit_proofs: list, link_proof: list, bits: int):
+    # Accept either tuple or list for link proof and forward to the bridge module.
+    return crypto.range_proof_verify(commitment, bit_commitments, bit_proofs, tuple(link_proof), bits)

--- a/tests/integration/test_crypto_metering.py
+++ b/tests/integration/test_crypto_metering.py
@@ -1,0 +1,76 @@
+from unittest import TestCase
+from contracting.execution import runtime
+from contracting.stdlib import env
+from contracting.stdlib.bridge import crypto as C
+import copy
+
+from tests.unit.test_crypto import make_range_proof
+
+
+class TestCryptoContractMetering(TestCase):
+    def setUp(self):
+        scope = env.gather()
+        scope['__contract__'] = True
+
+        contract_source = """
+def commit(value, blinding):
+    return crypto.pedersen_commit(str(value), blinding)
+
+def verify_range(commitment, bit_commitments, bit_proofs, link_proof, bits):
+    return crypto.range_proof_verify(commitment, bit_commitments, bit_proofs, tuple(link_proof), bits)
+"""
+        exec(contract_source, scope)
+        self.scope = scope
+
+    def tearDown(self):
+        runtime.rt.clean_up()
+
+    def _run_metered(self, func, *args, **kwargs):
+        func.__globals__['__contract__'] = True
+        runtime.rt.set_up(stmps=1_000_000, meter=True)
+        try:
+            result = func(*args, **kwargs)
+            stamps = runtime.rt.tracer.get_stamp_used()
+            return result, stamps
+        finally:
+            runtime.rt.clean_up()
+
+    def test_pedersen_commit_is_deterministic_under_metering(self):
+        commit = self.scope['commit']
+
+        value = 1337
+        blinding = "11" * 32
+        expected = C.pedersen_commit(str(value), blinding)
+
+        first_result, first_stamps = self._run_metered(commit, value, blinding)
+        second_result, second_stamps = self._run_metered(commit, value, blinding)
+
+        self.assertEqual(first_result, expected)
+        self.assertEqual(second_result, expected)
+        self.assertEqual(first_result, second_result)
+        self.assertGreater(first_stamps, 0)
+        self.assertEqual(first_stamps, second_stamps)
+
+    def test_range_proof_verify_metering_is_stable(self):
+        verify_range = self.scope['verify_range']
+
+        bits = 8
+        value = 173
+        C_amt_hex, bit_cmts, bit_proofs, link_pf = make_range_proof(value, bits=bits)
+        self.assertTrue(C.range_proof_verify(C_amt_hex, bit_cmts, bit_proofs, link_pf, bits))
+
+        args = (
+            C_amt_hex,
+            list(bit_cmts),
+            copy.deepcopy(bit_proofs),
+            list(link_pf),
+            bits,
+        )
+
+        first_result, first_stamps = self._run_metered(verify_range, *args)
+        second_result, second_stamps = self._run_metered(verify_range, *args)
+
+        self.assertTrue(first_result)
+        self.assertTrue(second_result)
+        self.assertGreater(first_stamps, 0)
+        self.assertEqual(first_stamps, second_stamps)

--- a/tests/unit/test_crypto.py
+++ b/tests/unit/test_crypto.py
@@ -186,6 +186,12 @@ class TestCryptoModule(TestCase):
         c2 = C.pedersen_commit(v, r_hex)
         self.assertEqual(c1, c2)  # deterministic
 
+        # Zero-value path should remain deterministic as well (exercise v_scalar == 0 branch)
+        zero_blind = "33" * 32
+        z1 = C.pedersen_commit("0", zero_blind)
+        z2 = C.pedersen_commit("0", zero_blind)
+        self.assertEqual(z1, z2)
+
         # C + (-C) == identity (encoded point is canonical)
         neg = C.pedersen_neg(c1)
         zero = C.pedersen_add(c1, neg)
@@ -211,8 +217,10 @@ class TestCryptoModule(TestCase):
         # Build a valid 8-bit proof for a small value
         value = 173  # 0b10101101
         C_amt_hex, bit_cmts, bit_proofs, link_pf = make_range_proof(value, bits=8)
-        ok = C.range_proof_verify(C_amt_hex, bit_cmts, bit_proofs, link_pf, 8)
-        self.assertTrue(ok)
+        ok1 = C.range_proof_verify(C_amt_hex, bit_cmts, bit_proofs, link_pf, 8)
+        ok2 = C.range_proof_verify(C_amt_hex, bit_cmts, bit_proofs, link_pf, 8)
+        self.assertTrue(ok1)
+        self.assertTrue(ok2)
 
     def test_range_proof_verify_rejects_tamper(self):
         value = 77


### PR DESCRIPTION
## Summary
- add a helper contract fixture that exposes crypto pedersen commitment and range proof verification entry points
- extend unit crypto tests to exercise zero-value commitments and repeat range proof verification for determinism
- add integration-style tests that execute the crypto helpers under the runtime tracer to assert deterministic results and metering stability

## Testing
- PYTHONPATH=src pytest tests/unit/test_crypto.py tests/integration/test_crypto_metering.py

------
https://chatgpt.com/codex/tasks/task_e_6905bd0143488320b1a42529735adc08