### PR TITLE
Remove pedersen_commit bridge API and update tests

### DIFF
--- a/src/contracting/stdlib/bridge/crypto.py
+++ b/src/contracting/stdlib/bridge/crypto.py
@@ -65,12 +65,6 @@ def _require_point_hex(h: str, name: str):
     b = bytes.fromhex(h)
     assert bool(sodium.crypto_core_ristretto255_is_valid_point(b)), f"{name} is not canonical"
 
-def _u128_from_dec(ds: str) -> int:
-    assert isinstance(ds, str) and ds.isdigit(), "value_u128 must be decimal string"
-    v = int(ds, 10)
-    assert 0 <= v <= (1 << 128) - 1, "value_u128 out of range"
-    return v
-
 def _scalar_from_u128(v: int) -> bytes:
     # libsodium expects 64B input to scalar_reduce
     return sodium.crypto_core_ristretto255_scalar_reduce(v.to_bytes(64, "little"))
@@ -88,32 +82,6 @@ def _scalar_one() -> bytes:
 # Fixed second generator H via hash-to-group (deterministic & domain-separated)
 _H_HASH = hashlib.sha512(b"XIAN|crypto.pedersen|H").digest()  # 64 bytes
 H_POINT = sodium.crypto_core_ristretto255_from_hash(_H_HASH)  # 32B point (bytes)
-
-def pedersen_commit(value_u128: str, blinding_hex: str) -> str:
-    """
-    C = v*G + r*H  on Ristretto255.
-    value_u128: decimal string "0".."2^128-1"
-    blinding_hex: 32-byte hex (secret; mapped to scalar via SHA-512 then reduce)
-    Returns 32-byte point hex.
-    """
-    v_int = _u128_from_dec(value_u128)
-    _require_hex32(blinding_hex, "blinding_hex")
-
-    v_scalar = _scalar_from_u128(v_int)
-    r_seed = bytes.fromhex(blinding_hex)
-    r64 = hashlib.sha512(b"XIAN|crypto.pedersen|r|" + r_seed).digest()
-    r_scalar = sodium.crypto_core_ristretto255_scalar_reduce(r64)
-
-    if v_scalar == bytes(32):
-        # libsodium rejects the zero scalar for direct base multiplication, but
-        # the Pedersen commitment still needs the identity element when the
-        # value is 0. Compute it via H-H which yields the canonical identity
-        # encoding.
-        vG = sodium.crypto_core_ristretto255_sub(H_POINT, H_POINT)
-    else:
-        vG = sodium.crypto_scalarmult_ristretto255_base(v_scalar)
-    rH = sodium.crypto_scalarmult_ristretto255(r_scalar, H_POINT)
-    return sodium.crypto_core_ristretto255_add(vG, rH).hex()
 
 def pedersen_add(a_hex: str, b_hex: str) -> str:
     _require_point_hex(a_hex, "a_hex"); _require_point_hex(b_hex, "b_hex")
@@ -287,7 +255,6 @@ crypto_module = ModuleType('crypto')
 crypto_module.verify = verify
 crypto_module.key_is_valid = key_is_valid
 
-crypto_module.pedersen_commit = pedersen_commit
 crypto_module.pedersen_add = pedersen_add
 crypto_module.pedersen_sub = pedersen_sub
 crypto_module.pedersen_neg = pedersen_neg

--- a/tests/integration/test_crypto_metering.py
+++ b/tests/integration/test_crypto_metering.py
@@ -1,0 +1,122 @@
+from unittest import TestCase
+from contracting.execution import runtime
+from contracting.stdlib import env
+from contracting.stdlib.bridge import crypto as C
+import copy
+
+from tests.unit.test_crypto import make_range_proof, pedersen_commit_for_tests
+
+
+class TestCryptoContractMetering(TestCase):
+    def setUp(self):
+        scope = env.gather()
+        scope['__contract__'] = True
+
+        contract_source = """
+def pedersen_add(a, b):
+    return crypto.pedersen_add(a, b)
+
+def pedersen_sub(a, b):
+    return crypto.pedersen_sub(a, b)
+
+def pedersen_neg(value):
+    return crypto.pedersen_neg(value)
+
+def pedersen_eq(a, b):
+    return crypto.pedersen_eq(a, b)
+
+def verify_range(commitment, bit_commitments, bit_proofs, link_proof, bits):
+    return crypto.range_proof_verify(commitment, bit_commitments, bit_proofs, tuple(link_proof), bits)
+"""
+        exec(contract_source, scope)
+        self.scope = scope
+
+    def tearDown(self):
+        runtime.rt.clean_up()
+
+    def _run_metered(self, func, *args, **kwargs):
+        func.__globals__['__contract__'] = True
+        runtime.rt.set_up(stmps=1_000_000, meter=True)
+        try:
+            result = func(*args, **kwargs)
+            stamps = runtime.rt.tracer.get_stamp_used()
+            return result, stamps
+        finally:
+            runtime.rt.clean_up()
+
+    def test_pedersen_group_ops_are_deterministic_under_metering(self):
+        pedersen_add = self.scope['pedersen_add']
+        pedersen_sub = self.scope['pedersen_sub']
+        pedersen_neg = self.scope['pedersen_neg']
+        pedersen_eq = self.scope['pedersen_eq']
+
+        v1 = "1337"
+        v2 = "4242"
+        r1 = "11" * 32
+        r2 = "22" * 32
+
+        c1 = pedersen_commit_for_tests(v1, r1)
+        c2 = pedersen_commit_for_tests(v2, r2)
+
+        expected_sum = C.pedersen_add(c1, c2)
+        expected_diff = C.pedersen_sub(c1, c2)
+        expected_neg = C.pedersen_neg(c1)
+
+        add_result, add_stamps = self._run_metered(pedersen_add, c1, c2)
+        add_again, add_stamps_again = self._run_metered(pedersen_add, c1, c2)
+        self.assertEqual(add_result, expected_sum)
+        self.assertEqual(add_again, expected_sum)
+        self.assertGreater(add_stamps, 0)
+        self.assertEqual(add_stamps, add_stamps_again)
+
+        sub_result, sub_stamps = self._run_metered(pedersen_sub, c1, c2)
+        sub_again, sub_stamps_again = self._run_metered(pedersen_sub, c1, c2)
+        self.assertEqual(sub_result, expected_diff)
+        self.assertEqual(sub_again, expected_diff)
+        self.assertGreater(sub_stamps, 0)
+        self.assertEqual(sub_stamps, sub_stamps_again)
+
+        neg_result, neg_stamps = self._run_metered(pedersen_neg, c1)
+        neg_again, neg_stamps_again = self._run_metered(pedersen_neg, c1)
+        self.assertEqual(neg_result, expected_neg)
+        self.assertEqual(neg_again, expected_neg)
+        self.assertGreater(neg_stamps, 0)
+        self.assertEqual(neg_stamps, neg_stamps_again)
+
+        eq_result, eq_stamps = self._run_metered(pedersen_eq, c1, expected_sum)
+        eq_again, eq_stamps_again = self._run_metered(pedersen_eq, c1, expected_sum)
+        self.assertFalse(eq_result)
+        self.assertFalse(eq_again)
+        self.assertGreater(eq_stamps, 0)
+        self.assertEqual(eq_stamps, eq_stamps_again)
+
+        eq_true, eq_true_stamps = self._run_metered(pedersen_eq, c1, c1)
+        eq_true_again, eq_true_stamps_again = self._run_metered(pedersen_eq, c1, c1)
+        self.assertTrue(eq_true)
+        self.assertTrue(eq_true_again)
+        self.assertGreater(eq_true_stamps, 0)
+        self.assertEqual(eq_true_stamps, eq_true_stamps_again)
+
+    def test_range_proof_verify_metering_is_stable(self):
+        verify_range = self.scope['verify_range']
+
+        bits = 8
+        value = 173
+        C_amt_hex, bit_cmts, bit_proofs, link_pf = make_range_proof(value, bits=bits)
+        self.assertTrue(C.range_proof_verify(C_amt_hex, bit_cmts, bit_proofs, link_pf, bits))
+
+        args = (
+            C_amt_hex,
+            list(bit_cmts),
+            copy.deepcopy(bit_proofs),
+            list(link_pf),
+            bits,
+        )
+
+        first_result, first_stamps = self._run_metered(verify_range, *args)
+        second_result, second_stamps = self._run_metered(verify_range, *args)
+
+        self.assertTrue(first_result)
+        self.assertTrue(second_result)
+        self.assertGreater(first_stamps, 0)
+        self.assertEqual(first_stamps, second_stamps)

--- a/tests/unit/test_crypto.py
+++ b/tests/unit/test_crypto.py
@@ -39,6 +39,26 @@ def _hash_to_scalar(ctx: bytes) -> bytes:
     return _scalar_reduce_from_bytes(hashlib.sha512(ctx).digest())
 
 
+def pedersen_commit_for_tests(value_u128: str, blinding_hex: str) -> str:
+    assert isinstance(value_u128, str) and value_u128.isdigit(), "value must be decimal string"
+    v_int = int(value_u128, 10)
+    assert 0 <= v_int <= (1 << 128) - 1, "value out of range"
+    assert isinstance(blinding_hex, str) and len(blinding_hex) == 64, "blinding must be 32-byte hex"
+    _ = int(blinding_hex, 16)  # raises if non-hex
+
+    v_scalar = _scalar_from_u128(v_int)
+    r_seed = bytes.fromhex(blinding_hex)
+    r64 = hashlib.sha512(b"XIAN|crypto.pedersen|r|" + r_seed).digest()
+    r_scalar = _scalar_reduce_from_bytes(r64)
+
+    if v_scalar == bytes(32):
+        vG = _point_sub(H_POINT, H_POINT)
+    else:
+        vG = sodium.crypto_scalarmult_ristretto255_base(v_scalar)
+    rH = _point_mul(H_POINT, r_scalar)
+    return _point_add(vG, rH).hex()
+
+
 # === In-test prover for the Σ-protocol range proof ===========================
 
 def make_bit_commitment_and_proof(bit: int, r_hex: str):
@@ -48,7 +68,7 @@ def make_bit_commitment_and_proof(bit: int, r_hex: str):
     """
     assert bit in (0, 1)
     # Commitment C_i = b*G + r*H (use module under test)
-    Ci_hex = C.pedersen_commit(str(bit), r_hex)  # 32B hex
+    Ci_hex = pedersen_commit_for_tests(str(bit), r_hex)  # 32B hex
     Ci = bytes.fromhex(Ci_hex)
     Ci_minus_G = _point_sub(Ci, G_POINT)
 
@@ -114,7 +134,7 @@ def make_range_proof(amount_value: int, bits: int = 8):
     assert 0 <= amount_value < (1 << bits)
     # Amount & blinding
     r_amt_hex = os.urandom(32).hex()
-    C_amt_hex = C.pedersen_commit(str(amount_value), r_amt_hex)
+    C_amt_hex = pedersen_commit_for_tests(str(amount_value), r_amt_hex)
     C_amt = bytes.fromhex(C_amt_hex)
 
     # Bits
@@ -179,12 +199,20 @@ class TestCryptoModule(TestCase):
         self.assertTrue(C.verify(vk_hex, msg, sig_hex))
         self.assertFalse(C.verify(vk_hex, msg + "!", sig_hex))
 
-    def test_pedersen_commit_determinism_and_ops(self):
+    def test_pedersen_group_ops_with_locally_built_commitments(self):
+        self.assertFalse(hasattr(C, 'pedersen_commit'))
+
         v = "123456"
         r_hex = "11" * 32
-        c1 = C.pedersen_commit(v, r_hex)
-        c2 = C.pedersen_commit(v, r_hex)
-        self.assertEqual(c1, c2)  # deterministic
+        c1 = pedersen_commit_for_tests(v, r_hex)
+        c2 = pedersen_commit_for_tests(v, r_hex)
+        self.assertEqual(c1, c2)  # deterministic even when built locally
+
+        # Zero-value path should remain deterministic as well (exercise v_scalar == 0 branch)
+        zero_blind = "33" * 32
+        z1 = pedersen_commit_for_tests("0", zero_blind)
+        z2 = pedersen_commit_for_tests("0", zero_blind)
+        self.assertEqual(z1, z2)
 
         # C + (-C) == identity (encoded point is canonical)
         neg = C.pedersen_neg(c1)
@@ -194,13 +222,13 @@ class TestCryptoModule(TestCase):
 
         # Add/sub roundtrip
         r2_hex = "22" * 32
-        d = C.pedersen_commit("1", r2_hex)
+        d = pedersen_commit_for_tests("1", r2_hex)
         rtrip = C.pedersen_sub(C.pedersen_add(c1, d), d)
         self.assertTrue(C.pedersen_eq(c1, rtrip))
 
     def test_ristretto_is_canonical(self):
         v = "0"; r_hex = "33" * 32
-        c = C.pedersen_commit(v, r_hex)
+        c = pedersen_commit_for_tests(v, r_hex)
         self.assertTrue(C.ristretto_is_canonical(c))
         # Break hex length
         self.assertFalse(C.ristretto_is_canonical(c[:-2]))
@@ -211,8 +239,10 @@ class TestCryptoModule(TestCase):
         # Build a valid 8-bit proof for a small value
         value = 173  # 0b10101101
         C_amt_hex, bit_cmts, bit_proofs, link_pf = make_range_proof(value, bits=8)
-        ok = C.range_proof_verify(C_amt_hex, bit_cmts, bit_proofs, link_pf, 8)
-        self.assertTrue(ok)
+        ok1 = C.range_proof_verify(C_amt_hex, bit_cmts, bit_proofs, link_pf, 8)
+        ok2 = C.range_proof_verify(C_amt_hex, bit_cmts, bit_proofs, link_pf, 8)
+        self.assertTrue(ok1)
+        self.assertTrue(ok2)
 
     def test_range_proof_verify_rejects_tamper(self):
         value = 77


### PR DESCRIPTION
## Summary
- drop the pedersen_commit helper from the crypto bridge so it is no longer callable from contracts
- add a local Pedersen commitment helper inside the crypto tests to keep generating fixtures
- update the unit and metering tests to use the local helper and assert the contract bridge no longer exposes pedersen_commit

## Testing
- PYTHONPATH=src pytest tests/unit/test_crypto.py tests/integration/test_crypto_metering.py *(fails: ModuleNotFoundError: No module named 'pysodium')*

------
https://chatgpt.com/codex/tasks/task_e_6905bd0143488320b1a42529735adc08