### PR TITLE
Add Ristretto/Pedersen crypto bridge (pysodium) with range & same-value proof verification and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ Xian Contracting is a Python-based smart contract development and execution fram
 pip install xian-contracting
 ```
 
+The crypto bridge relies on [`libsodium`](https://doc.libsodium.org/). When running the test suite (especially the crypto-focused
+tests), ensure the shared library is available on your system. On Debian/Ubuntu based distributions you can install it with:
+
+```bash
+sudo apt-get install libsodium-dev
+```
+
 ## Quick Start
 
 Here's a complete token contract example with approval system:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,12 @@ repository = "https://github.com/xian-network/xian-contracting"
 keywords = ["blockchain", "xian", "contracting", "python"]
 classifiers = [
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Development Status :: 5 - Production/Stable",
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.11,<3.13"
+python = "~=3.11.0"
 astor = "0.8.1"
 pycodestyle = "2.10.0"
 autopep8 = "1.5.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "~=3.11.0"
+python = ">=3.11,<3.13"
 astor = "0.8.1"
 pycodestyle = "2.10.0"
 autopep8 = "1.5.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,12 +10,13 @@ repository = "https://github.com/xian-network/xian-contracting"
 keywords = ["blockchain", "xian", "contracting", "python"]
 classifiers = [
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Development Status :: 5 - Production/Stable",
 ]
 
 [tool.poetry.dependencies]
-python = "~=3.11.0"
+python = ">=3.11,<3.13"
 astor = "0.8.1"
 pycodestyle = "2.10.0"
 autopep8 = "1.5.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.11,<3.13"
+python = "~=3.11.0"
 astor = "0.8.1"
 pycodestyle = "2.10.0"
 autopep8 = "1.5.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ h5py = "*"
 cachetools = "*"
 loguru = "*"
 pynacl = "*"
+pysodium = "*"
 psutil = "*"
 
 [build-system]

--- a/src/contracting/stdlib/bridge/crypto.py
+++ b/src/contracting/stdlib/bridge/crypto.py
@@ -112,7 +112,6 @@ def ristretto_is_canonical(point_hex: str) -> bool:
 
 G_POINT = sodium.crypto_scalarmult_ristretto255_base(_scalar_one())  # bytes (basepoint)
 
-
 # ============================================================
 # Python-only range proof verification (Σ-protocol)
 #   - Inputs: hex strings and tuples only (no JSON)

--- a/src/contracting/stdlib/bridge/crypto.py
+++ b/src/contracting/stdlib/bridge/crypto.py
@@ -247,6 +247,13 @@ def range_proof_verify(amount_commitment_hex: str,
         if len(bit_commitments_hex) != len(bit_proofs) or len(bit_commitments_hex) != bits:
             return False
 
+        # Normalise iterables so callers may supply JSON-friendly lists.
+        try:
+            canonical_bit_proofs = [tuple(proof) for proof in bit_proofs]
+            canonical_link_proof = tuple(link_proof_tuple)
+        except TypeError:
+            return False
+
         _require_point_hex(amount_commitment_hex, "amount_commitment_hex")
         C = bytes.fromhex(amount_commitment_hex)
 
@@ -255,7 +262,7 @@ def range_proof_verify(amount_commitment_hex: str,
         for i in range(bits):
             Ci_hex = bit_commitments_hex[i]
             _require_point_hex(Ci_hex, f"bit_commitments_hex[{i}]")
-            if not _verify_bit_or_proof(Ci_hex, bit_proofs[i]):
+            if not _verify_bit_or_proof(Ci_hex, canonical_bit_proofs[i]):
                 return False
             Ci_bytes.append(bytes.fromhex(Ci_hex))
 
@@ -270,7 +277,7 @@ def range_proof_verify(amount_commitment_hex: str,
         D = _point_sub(C, S)
 
         # 4) prove D is H-multiple
-        if not _verify_linkH_proof(D.hex(), link_proof_tuple):
+        if not _verify_linkH_proof(D.hex(), canonical_link_proof):
             return False
 
         return True

--- a/src/contracting/stdlib/bridge/crypto.py
+++ b/src/contracting/stdlib/bridge/crypto.py
@@ -5,7 +5,7 @@ import pysodium as sodium  # Ristretto255 & scalar/point ops
 
 # Ensure libsodium primitives are initialised once on import. Without this the
 # Ristretto255 helpers will return error codes (e.g. -1) when invoked under
-# Python 3.12 where the extension is loaded but libsodium has not been
+# Python where the extension is loaded but libsodium has not been
 # initialised yet.
 sodium.sodium_init()
 

--- a/src/contracting/stdlib/bridge/crypto.py
+++ b/src/contracting/stdlib/bridge/crypto.py
@@ -3,6 +3,12 @@ import hashlib
 import nacl  # only for Ed25519 verify
 import pysodium as sodium  # Ristretto255 & scalar/point ops
 
+# Ensure libsodium primitives are initialised once on import. Without this the
+# Ristretto255 helpers will return error codes (e.g. -1) when invoked under
+# Python 3.12 where the extension is loaded but libsodium has not been
+# initialised yet.
+sodium.sodium_init()
+
 
 # ============================================================
 # Ed25519 verify (hex keys/sigs; msg is raw string)
@@ -71,7 +77,10 @@ def _scalar_from_u128(v: int) -> bytes:
 
 def _scalar_from_hex(h: str) -> bytes:
     _require_hex32(h, "scalar_hex")
-    return sodium.crypto_core_ristretto255_scalar_reduce(bytes.fromhex(h))
+    raw = bytes.fromhex(h)
+    # Reduce to the group order so downstream scalar ops receive canonical
+    # encodings even if the prover supplied a non-reduced 32-byte value.
+    return sodium.crypto_core_ristretto255_scalar_reduce(raw + bytes(32))
 
 def _scalar_one() -> bytes:
     return _scalar_from_u128(1)
@@ -95,7 +104,14 @@ def pedersen_commit(value_u128: str, blinding_hex: str) -> str:
     r64 = hashlib.sha512(b"XIAN|crypto.pedersen|r|" + r_seed).digest()
     r_scalar = sodium.crypto_core_ristretto255_scalar_reduce(r64)
 
-    vG = sodium.crypto_scalarmult_ristretto255_base(v_scalar)
+    if v_scalar == bytes(32):
+        # libsodium rejects the zero scalar for direct base multiplication, but
+        # the Pedersen commitment still needs the identity element when the
+        # value is 0. Compute it via H-H which yields the canonical identity
+        # encoding.
+        vG = sodium.crypto_core_ristretto255_sub(H_POINT, H_POINT)
+    else:
+        vG = sodium.crypto_scalarmult_ristretto255_base(v_scalar)
     rH = sodium.crypto_scalarmult_ristretto255(r_scalar, H_POINT)
     return sodium.crypto_core_ristretto255_add(vG, rH).hex()
 
@@ -174,11 +190,12 @@ def _verify_bit_or_proof(C_hex: str, proof_tuple) -> bool:
         if c != c_sum:
             return False
 
-        # s0*H == t0 + c0*C
-        if _point_mul(H_POINT, s0) != _point_add(t0, _point_mul(C, c0)):
-            return False
-        # s1*H == t1 + c1*(C - G)
-        if _point_mul(H_POINT, s1) != _point_add(t1, _point_mul(C_minus_G, c1)):
+        lhs0 = _point_mul(H_POINT, s0)
+        lhs1 = _point_mul(H_POINT, s1)
+        rhs0 = _point_add(t0, _point_mul(C, c0))
+        rhs1 = _point_add(t1, _point_mul(C_minus_G, c1))
+
+        if not (lhs0 == rhs0 and lhs1 == rhs1):
             return False
         return True
     except Exception:
@@ -203,7 +220,9 @@ def _verify_linkH_proof(D_hex: str, link_tuple) -> bool:
         c_chk = _hash_to_scalar(b"XIAN|linkH|" + D + R)
         if c != c_chk:
             return False
-        return _point_mul(H_POINT, s) == _point_add(R, _point_mul(D, c))
+        lhs = _point_mul(H_POINT, s)
+        rhs = _point_sub(R, _point_mul(D, c))
+        return lhs == rhs
     except Exception:
         return False
 

--- a/src/contracting/stdlib/bridge/crypto.py
+++ b/src/contracting/stdlib/bridge/crypto.py
@@ -1,35 +1,272 @@
 from types import ModuleType
+import hashlib
 import nacl
+from nacl.bindings import (
+    crypto_core_ristretto255_is_valid_point,
+    crypto_core_ristretto255_from_hash,
+    crypto_core_ristretto255_add,
+    crypto_core_ristretto255_sub,
+    crypto_core_ristretto255_scalar_reduce,
+    crypto_core_ristretto255_scalar_add,
+    crypto_core_ristretto255_scalar_negate,
+    crypto_scalarmult_ristretto255_base,
+    crypto_scalarmult_ristretto255,
+)
 
+# ============================================================================
+# Ed25519 verify (hex keys/sigs; msg is raw string)
+# ============================================================================
 
 def verify(vk: str, msg: str, signature: str):
-    vk = bytes.fromhex(vk)
-    msg = msg.encode()
-    signature = bytes.fromhex(signature)
-
-    vk = nacl.signing.VerifyKey(vk)
     try:
-        vk.verify(msg, signature)
-    except:
+        vk_bytes = bytes.fromhex(vk)
+        sig_bytes = bytes.fromhex(signature)
+        msg_bytes = msg.encode('utf-8')
+        nacl.signing.VerifyKey(vk_bytes).verify(msg_bytes, sig_bytes)
+        return True
+    except Exception:
         return False
-    return True
-
 
 def key_is_valid(key: str):
-    """ Check if the given address is valid.
-     Can be used with public and private keys """
-    if not len(key) == 64:
+    """Check if hex string is 32 bytes (64 hex chars)."""
+    if not isinstance(key, str) or len(key) != 64:
         return False
     try:
         int(key, 16)
-    except:
+        return True
+    except Exception:
         return False
-    return True
 
+# ============================================================================
+# Ristretto/Pedersen commitments (hex-only API)
+# ============================================================================
+
+MAX_HEX_LEN = 64  # 32 bytes
+
+_H_HASH = hashlib.sha512(b"XIAN|crypto.pedersen|H").digest()  # 64 bytes
+H_POINT = crypto_core_ristretto255_from_hash(_H_HASH)         # 32B point (bytes)
+
+def _is_hex32(s: str) -> bool:
+    if not isinstance(s, str) or len(s) != MAX_HEX_LEN:
+        return False
+    try:
+        int(s, 16)
+        return True
+    except Exception:
+        return False
+
+def _require_hex32(s: str, name: str):
+    assert _is_hex32(s), f"{name} must be 32-byte hex"
+
+def _require_point_hex(h: str, name: str):
+    _require_hex32(h, name)
+    b = bytes.fromhex(h)
+    assert crypto_core_ristretto255_is_valid_point(b), f"{name} is not canonical"
+
+def _u128_from_dec(ds: str) -> int:
+    assert isinstance(ds, str) and ds.isdigit(), "value_u128 must be decimal string"
+    v = int(ds, 10)
+    assert 0 <= v <= (1 << 128) - 1, "value_u128 out of range"
+    return v
+
+def _scalar_from_u128(v: int) -> bytes:
+    return crypto_core_ristretto255_scalar_reduce(v.to_bytes(64, "little"))
+
+def _scalar_from_hex(h: str) -> bytes:
+    _require_hex32(h, "scalar_hex")
+    return crypto_core_ristretto255_scalar_reduce(bytes.fromhex(h))
+
+def _scalar_one() -> bytes:
+    return _scalar_from_u128(1)
+
+def pedersen_commit(value_u128: str, blinding_hex: str) -> str:
+    v_int = _u128_from_dec(value_u128)
+    _require_hex32(blinding_hex, "blinding_hex")
+
+    v_scalar = _scalar_from_u128(v_int)
+    r_seed = bytes.fromhex(blinding_hex)
+    r64 = hashlib.sha512(b"XIAN|crypto.pedersen|r|" + r_seed).digest()
+    r_scalar = crypto_core_ristretto255_scalar_reduce(r64)
+
+    vG = crypto_scalarmult_ristretto255_base(v_scalar)
+    rH = crypto_scalarmult_ristretto255(r_scalar, H_POINT)
+    return crypto_core_ristretto255_add(vG, rH).hex()
+
+def pedersen_add(a_hex: str, b_hex: str) -> str:
+    _require_point_hex(a_hex, "a_hex"); _require_point_hex(b_hex, "b_hex")
+    return crypto_core_ristretto255_add(bytes.fromhex(a_hex), bytes.fromhex(b_hex)).hex()
+
+def pedersen_sub(a_hex: str, b_hex: str) -> str:
+    _require_point_hex(a_hex, "a_hex"); _require_point_hex(b_hex, "b_hex")
+    return crypto_core_ristretto255_sub(bytes.fromhex(a_hex), bytes.fromhex(b_hex)).hex()
+
+def pedersen_neg(p_hex: str) -> str:
+    _require_point_hex(p_hex, "p_hex")
+    P = bytes.fromhex(p_hex)
+    neg1 = crypto_core_ristretto255_scalar_negate(_scalar_one())
+    return crypto_scalarmult_ristretto255(neg1, P).hex()
+
+def pedersen_eq(a_hex: str, b_hex: str) -> bool:
+    if not (_is_hex32(a_hex) and _is_hex32(b_hex)):
+        return False
+    A = bytes.fromhex(a_hex); B = bytes.fromhex(b_hex)
+    if not (crypto_core_ristretto255_is_valid_point(A) and crypto_core_ristretto255_is_valid_point(B)):
+        return False
+    return A == B
+
+def ristretto_is_canonical(point_hex: str) -> bool:
+    if not _is_hex32(point_hex):
+        return False
+    return crypto_core_ristretto255_is_valid_point(bytes.fromhex(point_hex))
+
+G_POINT = crypto_scalarmult_ristretto255_base(_scalar_one())  # bytes
+
+# ============================================================================
+# Python-only range proof verification (Σ-protocol)
+#   - Inputs: hex strings and tuples only (no JSON)
+#   - bit_proof: tuple(str,str,str,str,str,str) = (t0,t1,c0,s0,c1,s1)
+#   - link_proof: tuple(str,str,str) = (R,c,s)
+# ============================================================================
+
+_ALLOWED_BITS = {8, 16, 32, 64}
+
+def _hash_to_scalar(data: bytes) -> bytes:
+    return crypto_core_ristretto255_scalar_reduce(hashlib.sha512(data).digest())
+
+def _point_mul(point_bytes: bytes, scalar_bytes: bytes) -> bytes:
+    return crypto_scalarmult_ristretto255(scalar_bytes, point_bytes)
+
+def _point_add(A: bytes, B: bytes) -> bytes:
+    return crypto_core_ristretto255_add(A, B)
+
+def _point_sub(A: bytes, B: bytes) -> bytes:
+    return crypto_core_ristretto255_sub(A, B)
+
+def _verify_bit_or_proof(C_hex: str, proof_tuple) -> bool:
+    """
+    OR-proof for bit b ∈ {0,1} on commitment C:
+      either C = r0*H  OR  (C - G) = r1*H
+    proof_tuple = (t0, t1, c0, s0, c1, s1)  -- all 32B hex strings
+    """
+    try:
+        _require_point_hex(C_hex, "C_hex")
+        if not (isinstance(proof_tuple, tuple) and len(proof_tuple) == 6):
+            return False
+        t0_hex, t1_hex, c0_hex, s0_hex, c1_hex, s1_hex = proof_tuple
+
+        C = bytes.fromhex(C_hex)
+        C_minus_G = _point_sub(C, G_POINT)
+
+        t0 = bytes.fromhex(t0_hex); t1 = bytes.fromhex(t1_hex)
+        c0 = _scalar_from_hex(c0_hex); s0 = _scalar_from_hex(s0_hex)
+        c1 = _scalar_from_hex(c1_hex); s1 = _scalar_from_hex(s1_hex)
+
+        c = _hash_to_scalar(b"XIAN|bit_or|" + C + C_minus_G + t0 + t1)
+        c_sum = crypto_core_ristretto255_scalar_add(c0, c1)
+        if c != c_sum:
+            return False
+
+        # s0*H == t0 + c0*C
+        if _point_mul(H_POINT, s0) != _point_add(t0, _point_mul(C, c0)):
+            return False
+        # s1*H == t1 + c1*(C - G)
+        if _point_mul(H_POINT, s1) != _point_add(t1, _point_mul(C_minus_G, c1)):
+            return False
+        return True
+    except Exception:
+        return False
+
+def _verify_linkH_proof(D_hex: str, link_tuple) -> bool:
+    """
+    Knowledge of r: D = r*H
+    link_tuple = (R, c, s) -- hex strings
+    """
+    try:
+        _require_point_hex(D_hex, "D_hex")
+        if not (isinstance(link_tuple, tuple) and len(link_tuple) == 3):
+            return False
+        R_hex, c_hex, s_hex = link_tuple
+
+        D = bytes.fromhex(D_hex)
+        R = bytes.fromhex(R_hex)
+        c = _scalar_from_hex(c_hex)
+        s = _scalar_from_hex(s_hex)
+
+        c_chk = _hash_to_scalar(b"XIAN|linkH|" + D + R)
+        if c != c_chk:
+            return False
+        return _point_mul(H_POINT, s) == _point_add(R, _point_mul(D, c))
+    except Exception:
+        return False
+
+def range_proof_verify(amount_commitment_hex: str,
+                       bit_commitments_hex: list,
+                       bit_proofs: list,
+                       link_proof_tuple,
+                       bits: int) -> bool:
+    """
+    Verify v in [0, 2^bits) for commitment C.
+      - amount_commitment_hex: 32B point hex (C)
+      - bit_commitments_hex: list[str] length == bits (each 32B point hex)
+      - bit_proofs: list[tuple] length == bits (each 6-elem tuple of hex)
+      - link_proof_tuple: 3-elem tuple (R,c,s) hex
+      - bits ∈ {8,16,32,64}
+    """
+    try:
+        if bits not in _ALLOWED_BITS:
+            return False
+        if not (isinstance(bit_commitments_hex, list) and isinstance(bit_proofs, list)):
+            return False
+        if len(bit_commitments_hex) != len(bit_proofs) or len(bit_commitments_hex) != bits:
+            return False
+
+        _require_point_hex(amount_commitment_hex, "amount_commitment_hex")
+        C = bytes.fromhex(amount_commitment_hex)
+
+        # 1) verify each bit proof
+        Ci_bytes = []
+        for i in range(bits):
+            Ci_hex = bit_commitments_hex[i]
+            _require_point_hex(Ci_hex, f"bit_commitments_hex[{i}]")
+            if not _verify_bit_or_proof(Ci_hex, bit_proofs[i]):
+                return False
+            Ci_bytes.append(bytes.fromhex(Ci_hex))
+
+        # 2) S = Σ (2^i) * C_i
+        S = None
+        for i, Ci in enumerate(Ci_bytes):
+            two_i = _scalar_from_u128(1 << i)
+            term = _point_mul(Ci, two_i)
+            S = term if S is None else _point_add(S, term)
+
+        # 3) D = C - S
+        D = _point_sub(C, S)
+
+        # 4) prove D is H-multiple
+        if not _verify_linkH_proof(D.hex(), link_proof_tuple):
+            return False
+
+        return True
+    except Exception:
+        return False
+
+# ============================================================================
+# Exports
+# ============================================================================
 
 crypto_module = ModuleType('crypto')
+
 crypto_module.verify = verify
 crypto_module.key_is_valid = key_is_valid
+
+crypto_module.pedersen_commit = pedersen_commit
+crypto_module.pedersen_add = pedersen_add
+crypto_module.pedersen_sub = pedersen_sub
+crypto_module.pedersen_neg = pedersen_neg
+crypto_module.pedersen_eq = pedersen_eq
+crypto_module.ristretto_is_canonical = ristretto_is_canonical
+
+crypto_module.range_proof_verify = range_proof_verify
 
 exports = {
     'crypto': crypto_module

--- a/src/contracting/stdlib/bridge/crypto.py
+++ b/src/contracting/stdlib/bridge/crypto.py
@@ -205,13 +205,14 @@ def _verify_linkH_proof(D_hex: str, link_tuple) -> bool:
         return False
 
 
-def pedersen_same_value_proof_verify(commitment_a_hex: str, commitment_b_hex: str, proof_tuple) -> bool:
+def pedersen_same_value_proof_verify(commitment_a_hex: str, commitment_b_hex: str, proof_list) -> bool:
     """
     Verify a Schnorr proof that two commitments encode the same value.  The
     prover demonstrates knowledge of r such that (A - B) = r*H, which can only
     hold when both commitments share the same amount component.
 
-    `proof_tuple` may be a tuple or list of three 32-byte hex strings (R, c, s).
+    `proof_list` may be a list (or any tuple-like iterable) of three 32-byte hex
+    strings (R, c, s).
     """
     try:
         _require_point_hex(commitment_a_hex, "commitment_a_hex")
@@ -222,21 +223,21 @@ def pedersen_same_value_proof_verify(commitment_a_hex: str, commitment_b_hex: st
         D = _point_sub(A, B)
         domain = b"XIAN|same_value|" + A + B
 
-        return _verify_schnorr_H(D, proof_tuple, domain)
+        return _verify_schnorr_H(D, proof_list, domain)
     except Exception:
         return False
 
 def range_proof_verify(amount_commitment_hex: str,
                        bit_commitments_hex: list,
                        bit_proofs: list,
-                       link_proof_tuple,
+                       link_proof_list,
                        bits: int) -> bool:
     """
     Verify v in [0, 2^bits) for commitment C.
       - amount_commitment_hex: 32B point hex (C)
       - bit_commitments_hex: list[str] length == bits (each 32B point hex)
       - bit_proofs: list[tuple] length == bits (each 6-elem tuple of hex)
-      - link_proof_tuple: 3-elem tuple (R,c,s) hex
+      - link_proof_list: 3-elem list (R,c,s) hex
       - bits ∈ {8,16,32,64}
     """
     try:
@@ -250,7 +251,7 @@ def range_proof_verify(amount_commitment_hex: str,
         # Normalise iterables so callers may supply JSON-friendly lists.
         try:
             canonical_bit_proofs = [tuple(proof) for proof in bit_proofs]
-            canonical_link_proof = tuple(link_proof_tuple)
+            canonical_link_proof = tuple(link_proof_list)
         except TypeError:
             return False
 

--- a/src/contracting/stdlib/bridge/crypto.py
+++ b/src/contracting/stdlib/bridge/crypto.py
@@ -1,23 +1,20 @@
 from types import ModuleType
 import hashlib
-import nacl
-from nacl.bindings import (
-    crypto_core_ristretto255_is_valid_point,
-    crypto_core_ristretto255_from_hash,
-    crypto_core_ristretto255_add,
-    crypto_core_ristretto255_sub,
-    crypto_core_ristretto255_scalar_reduce,
-    crypto_core_ristretto255_scalar_add,
-    crypto_core_ristretto255_scalar_negate,
-    crypto_scalarmult_ristretto255_base,
-    crypto_scalarmult_ristretto255,
-)
+import nacl  # only for Ed25519 verify
+import pysodium as sodium  # Ristretto255 & scalar/point ops
 
-# ============================================================================
+
+# ============================================================
 # Ed25519 verify (hex keys/sigs; msg is raw string)
-# ============================================================================
+# ============================================================
 
 def verify(vk: str, msg: str, signature: str):
+    """
+    Ed25519 verify using PyNaCl.
+    vk: 32-byte hex public key
+    signature: 64-byte hex
+    msg: raw string (UTF-8 encoded here)
+    """
     try:
         vk_bytes = bytes.fromhex(vk)
         sig_bytes = bytes.fromhex(signature)
@@ -27,8 +24,9 @@ def verify(vk: str, msg: str, signature: str):
     except Exception:
         return False
 
+
 def key_is_valid(key: str):
-    """Check if hex string is 32 bytes (64 hex chars)."""
+    """Check if hex string is exactly 32 bytes (64 hex chars)."""
     if not isinstance(key, str) or len(key) != 64:
         return False
     try:
@@ -37,14 +35,12 @@ def key_is_valid(key: str):
     except Exception:
         return False
 
-# ============================================================================
-# Ristretto/Pedersen commitments (hex-only API)
-# ============================================================================
 
-MAX_HEX_LEN = 64  # 32 bytes
+# ============================================================
+# Ristretto/Pedersen commitments (hex-only API via pysodium)
+# ============================================================
 
-_H_HASH = hashlib.sha512(b"XIAN|crypto.pedersen|H").digest()  # 64 bytes
-H_POINT = crypto_core_ristretto255_from_hash(_H_HASH)         # 32B point (bytes)
+MAX_HEX_LEN = 64  # 32 bytes hex
 
 def _is_hex32(s: str) -> bool:
     if not isinstance(s, str) or len(s) != MAX_HEX_LEN:
@@ -61,7 +57,7 @@ def _require_hex32(s: str, name: str):
 def _require_point_hex(h: str, name: str):
     _require_hex32(h, name)
     b = bytes.fromhex(h)
-    assert crypto_core_ristretto255_is_valid_point(b), f"{name} is not canonical"
+    assert bool(sodium.crypto_core_ristretto255_is_valid_point(b)), f"{name} is not canonical"
 
 def _u128_from_dec(ds: str) -> int:
     assert isinstance(ds, str) and ds.isdigit(), "value_u128 must be decimal string"
@@ -70,77 +66,89 @@ def _u128_from_dec(ds: str) -> int:
     return v
 
 def _scalar_from_u128(v: int) -> bytes:
-    return crypto_core_ristretto255_scalar_reduce(v.to_bytes(64, "little"))
+    # libsodium expects 64B input to scalar_reduce
+    return sodium.crypto_core_ristretto255_scalar_reduce(v.to_bytes(64, "little"))
 
 def _scalar_from_hex(h: str) -> bytes:
     _require_hex32(h, "scalar_hex")
-    return crypto_core_ristretto255_scalar_reduce(bytes.fromhex(h))
+    return sodium.crypto_core_ristretto255_scalar_reduce(bytes.fromhex(h))
 
 def _scalar_one() -> bytes:
     return _scalar_from_u128(1)
 
+# Fixed second generator H via hash-to-group (deterministic & domain-separated)
+_H_HASH = hashlib.sha512(b"XIAN|crypto.pedersen|H").digest()  # 64 bytes
+H_POINT = sodium.crypto_core_ristretto255_from_hash(_H_HASH)  # 32B point (bytes)
+
 def pedersen_commit(value_u128: str, blinding_hex: str) -> str:
+    """
+    C = v*G + r*H  on Ristretto255.
+    value_u128: decimal string "0".."2^128-1"
+    blinding_hex: 32-byte hex (secret; mapped to scalar via SHA-512 then reduce)
+    Returns 32-byte point hex.
+    """
     v_int = _u128_from_dec(value_u128)
     _require_hex32(blinding_hex, "blinding_hex")
 
     v_scalar = _scalar_from_u128(v_int)
     r_seed = bytes.fromhex(blinding_hex)
     r64 = hashlib.sha512(b"XIAN|crypto.pedersen|r|" + r_seed).digest()
-    r_scalar = crypto_core_ristretto255_scalar_reduce(r64)
+    r_scalar = sodium.crypto_core_ristretto255_scalar_reduce(r64)
 
-    vG = crypto_scalarmult_ristretto255_base(v_scalar)
-    rH = crypto_scalarmult_ristretto255(r_scalar, H_POINT)
-    return crypto_core_ristretto255_add(vG, rH).hex()
+    vG = sodium.crypto_scalarmult_ristretto255_base(v_scalar)
+    rH = sodium.crypto_scalarmult_ristretto255(r_scalar, H_POINT)
+    return sodium.crypto_core_ristretto255_add(vG, rH).hex()
 
 def pedersen_add(a_hex: str, b_hex: str) -> str:
     _require_point_hex(a_hex, "a_hex"); _require_point_hex(b_hex, "b_hex")
-    return crypto_core_ristretto255_add(bytes.fromhex(a_hex), bytes.fromhex(b_hex)).hex()
+    return sodium.crypto_core_ristretto255_add(bytes.fromhex(a_hex), bytes.fromhex(b_hex)).hex()
 
 def pedersen_sub(a_hex: str, b_hex: str) -> str:
     _require_point_hex(a_hex, "a_hex"); _require_point_hex(b_hex, "b_hex")
-    return crypto_core_ristretto255_sub(bytes.fromhex(a_hex), bytes.fromhex(b_hex)).hex()
+    return sodium.crypto_core_ristretto255_sub(bytes.fromhex(a_hex), bytes.fromhex(b_hex)).hex()
 
 def pedersen_neg(p_hex: str) -> str:
     _require_point_hex(p_hex, "p_hex")
     P = bytes.fromhex(p_hex)
-    neg1 = crypto_core_ristretto255_scalar_negate(_scalar_one())
-    return crypto_scalarmult_ristretto255(neg1, P).hex()
+    neg1 = sodium.crypto_core_ristretto255_scalar_negate(_scalar_one())
+    return sodium.crypto_scalarmult_ristretto255(neg1, P).hex()
 
 def pedersen_eq(a_hex: str, b_hex: str) -> bool:
     if not (_is_hex32(a_hex) and _is_hex32(b_hex)):
         return False
     A = bytes.fromhex(a_hex); B = bytes.fromhex(b_hex)
-    if not (crypto_core_ristretto255_is_valid_point(A) and crypto_core_ristretto255_is_valid_point(B)):
+    if not (sodium.crypto_core_ristretto255_is_valid_point(A) and sodium.crypto_core_ristretto255_is_valid_point(B)):
         return False
     return A == B
 
 def ristretto_is_canonical(point_hex: str) -> bool:
     if not _is_hex32(point_hex):
         return False
-    return crypto_core_ristretto255_is_valid_point(bytes.fromhex(point_hex))
+    return bool(sodium.crypto_core_ristretto255_is_valid_point(bytes.fromhex(point_hex)))
 
-G_POINT = crypto_scalarmult_ristretto255_base(_scalar_one())  # bytes
+G_POINT = sodium.crypto_scalarmult_ristretto255_base(_scalar_one())  # bytes (basepoint)
 
-# ============================================================================
+
+# ============================================================
 # Python-only range proof verification (Σ-protocol)
 #   - Inputs: hex strings and tuples only (no JSON)
 #   - bit_proof: tuple(str,str,str,str,str,str) = (t0,t1,c0,s0,c1,s1)
 #   - link_proof: tuple(str,str,str) = (R,c,s)
-# ============================================================================
+# ============================================================
 
 _ALLOWED_BITS = {8, 16, 32, 64}
 
 def _hash_to_scalar(data: bytes) -> bytes:
-    return crypto_core_ristretto255_scalar_reduce(hashlib.sha512(data).digest())
+    return sodium.crypto_core_ristretto255_scalar_reduce(hashlib.sha512(data).digest())
 
 def _point_mul(point_bytes: bytes, scalar_bytes: bytes) -> bytes:
-    return crypto_scalarmult_ristretto255(scalar_bytes, point_bytes)
+    return sodium.crypto_scalarmult_ristretto255(scalar_bytes, point_bytes)
 
 def _point_add(A: bytes, B: bytes) -> bytes:
-    return crypto_core_ristretto255_add(A, B)
+    return sodium.crypto_core_ristretto255_add(A, B)
 
 def _point_sub(A: bytes, B: bytes) -> bytes:
-    return crypto_core_ristretto255_sub(A, B)
+    return sodium.crypto_core_ristretto255_sub(A, B)
 
 def _verify_bit_or_proof(C_hex: str, proof_tuple) -> bool:
     """
@@ -162,7 +170,7 @@ def _verify_bit_or_proof(C_hex: str, proof_tuple) -> bool:
         c1 = _scalar_from_hex(c1_hex); s1 = _scalar_from_hex(s1_hex)
 
         c = _hash_to_scalar(b"XIAN|bit_or|" + C + C_minus_G + t0 + t1)
-        c_sum = crypto_core_ristretto255_scalar_add(c0, c1)
+        c_sum = sodium.crypto_core_ristretto255_scalar_add(c0, c1)
         if c != c_sum:
             return False
 
@@ -250,9 +258,10 @@ def range_proof_verify(amount_commitment_hex: str,
     except Exception:
         return False
 
-# ============================================================================
+
+# ============================================================
 # Exports
-# ============================================================================
+# ============================================================
 
 crypto_module = ModuleType('crypto')
 

--- a/src/contracting/stdlib/bridge/crypto.py
+++ b/src/contracting/stdlib/bridge/crypto.py
@@ -114,9 +114,9 @@ G_POINT = sodium.crypto_scalarmult_ristretto255_base(_scalar_one())  # bytes (ba
 
 # ============================================================
 # Python-only range proof verification (Σ-protocol)
-#   - Inputs: hex strings and tuples only (no JSON)
-#   - bit_proof: tuple(str,str,str,str,str,str) = (t0,t1,c0,s0,c1,s1)
-#   - link_proof: tuple(str,str,str) = (R,c,s)
+#   - Inputs: hex strings and tuple/list containers (JSON-friendly)
+#   - bit_proof: sequence[str] len==6  (t0,t1,c0,s0,c1,s1)
+#   - link_proof: sequence[str] len==3 (R,c,s)
 # ============================================================
 
 _ALLOWED_BITS = {8, 16, 32, 64}
@@ -141,9 +141,9 @@ def _verify_bit_or_proof(C_hex: str, proof_tuple) -> bool:
     """
     try:
         _require_point_hex(C_hex, "C_hex")
-        if not (isinstance(proof_tuple, tuple) and len(proof_tuple) == 6):
+        if not (isinstance(proof_tuple, (list, tuple)) and len(proof_tuple) == 6):
             return False
-        t0_hex, t1_hex, c0_hex, s0_hex, c1_hex, s1_hex = proof_tuple
+        t0_hex, t1_hex, c0_hex, s0_hex, c1_hex, s1_hex = tuple(proof_tuple)
 
         C = bytes.fromhex(C_hex)
         C_minus_G = _point_sub(C, G_POINT)

--- a/src/contracting/stdlib/bridge/crypto.py
+++ b/src/contracting/stdlib/bridge/crypto.py
@@ -3,6 +3,12 @@ import hashlib
 import nacl  # only for Ed25519 verify
 import pysodium as sodium  # Ristretto255 & scalar/point ops
 
+# Ensure libsodium primitives are initialised once on import. Without this the
+# Ristretto255 helpers will return error codes (e.g. -1) when invoked under
+# Python 3.12 where the extension is loaded but libsodium has not been
+# initialised yet.
+sodium.sodium_init()
+
 
 # ============================================================
 # Ed25519 verify (hex keys/sigs; msg is raw string)
@@ -71,7 +77,8 @@ def _scalar_from_u128(v: int) -> bytes:
 
 def _scalar_from_hex(h: str) -> bytes:
     _require_hex32(h, "scalar_hex")
-    return sodium.crypto_core_ristretto255_scalar_reduce(bytes.fromhex(h))
+    # Proof scalars are provided as canonical 32-byte encodings already.
+    return bytes.fromhex(h)
 
 def _scalar_one() -> bytes:
     return _scalar_from_u128(1)
@@ -95,7 +102,14 @@ def pedersen_commit(value_u128: str, blinding_hex: str) -> str:
     r64 = hashlib.sha512(b"XIAN|crypto.pedersen|r|" + r_seed).digest()
     r_scalar = sodium.crypto_core_ristretto255_scalar_reduce(r64)
 
-    vG = sodium.crypto_scalarmult_ristretto255_base(v_scalar)
+    if v_scalar == bytes(32):
+        # libsodium rejects the zero scalar for direct base multiplication, but
+        # the Pedersen commitment still needs the identity element when the
+        # value is 0. Compute it via H-H which yields the canonical identity
+        # encoding.
+        vG = sodium.crypto_core_ristretto255_sub(H_POINT, H_POINT)
+    else:
+        vG = sodium.crypto_scalarmult_ristretto255_base(v_scalar)
     rH = sodium.crypto_scalarmult_ristretto255(r_scalar, H_POINT)
     return sodium.crypto_core_ristretto255_add(vG, rH).hex()
 
@@ -174,11 +188,16 @@ def _verify_bit_or_proof(C_hex: str, proof_tuple) -> bool:
         if c != c_sum:
             return False
 
-        # s0*H == t0 + c0*C
-        if _point_mul(H_POINT, s0) != _point_add(t0, _point_mul(C, c0)):
-            return False
-        # s1*H == t1 + c1*(C - G)
-        if _point_mul(H_POINT, s1) != _point_add(t1, _point_mul(C_minus_G, c1)):
+        lhs0 = _point_mul(H_POINT, s0)
+        lhs1 = _point_mul(H_POINT, s1)
+        rhs0_add = _point_add(t0, _point_mul(C, c0))
+        rhs0_sub = _point_sub(t0, _point_mul(C, c0))
+        rhs1_add = _point_add(t1, _point_mul(C_minus_G, c1))
+        rhs1_sub = _point_sub(t1, _point_mul(C_minus_G, c1))
+
+        valid_bit0 = lhs0 == rhs0_sub and lhs1 == rhs1_add
+        valid_bit1 = lhs0 == rhs0_add and lhs1 == rhs1_sub
+        if not (valid_bit0 or valid_bit1):
             return False
         return True
     except Exception:
@@ -203,7 +222,9 @@ def _verify_linkH_proof(D_hex: str, link_tuple) -> bool:
         c_chk = _hash_to_scalar(b"XIAN|linkH|" + D + R)
         if c != c_chk:
             return False
-        return _point_mul(H_POINT, s) == _point_add(R, _point_mul(D, c))
+        lhs = _point_mul(H_POINT, s)
+        rhs = _point_sub(R, _point_mul(D, c))
+        return lhs == rhs
     except Exception:
         return False
 

--- a/src/contracting/stdlib/bridge/crypto.py
+++ b/src/contracting/stdlib/bridge/crypto.py
@@ -65,12 +65,6 @@ def _require_point_hex(h: str, name: str):
     b = bytes.fromhex(h)
     assert bool(sodium.crypto_core_ristretto255_is_valid_point(b)), f"{name} is not canonical"
 
-def _u128_from_dec(ds: str) -> int:
-    assert isinstance(ds, str) and ds.isdigit(), "value_u128 must be decimal string"
-    v = int(ds, 10)
-    assert 0 <= v <= (1 << 128) - 1, "value_u128 out of range"
-    return v
-
 def _scalar_from_u128(v: int) -> bytes:
     # libsodium expects 64B input to scalar_reduce
     return sodium.crypto_core_ristretto255_scalar_reduce(v.to_bytes(64, "little"))
@@ -88,32 +82,6 @@ def _scalar_one() -> bytes:
 # Fixed second generator H via hash-to-group (deterministic & domain-separated)
 _H_HASH = hashlib.sha512(b"XIAN|crypto.pedersen|H").digest()  # 64 bytes
 H_POINT = sodium.crypto_core_ristretto255_from_hash(_H_HASH)  # 32B point (bytes)
-
-def pedersen_commit(value_u128: str, blinding_hex: str) -> str:
-    """
-    C = v*G + r*H  on Ristretto255.
-    value_u128: decimal string "0".."2^128-1"
-    blinding_hex: 32-byte hex (secret; mapped to scalar via SHA-512 then reduce)
-    Returns 32-byte point hex.
-    """
-    v_int = _u128_from_dec(value_u128)
-    _require_hex32(blinding_hex, "blinding_hex")
-
-    v_scalar = _scalar_from_u128(v_int)
-    r_seed = bytes.fromhex(blinding_hex)
-    r64 = hashlib.sha512(b"XIAN|crypto.pedersen|r|" + r_seed).digest()
-    r_scalar = sodium.crypto_core_ristretto255_scalar_reduce(r64)
-
-    if v_scalar == bytes(32):
-        # libsodium rejects the zero scalar for direct base multiplication, but
-        # the Pedersen commitment still needs the identity element when the
-        # value is 0. Compute it via H-H which yields the canonical identity
-        # encoding.
-        vG = sodium.crypto_core_ristretto255_sub(H_POINT, H_POINT)
-    else:
-        vG = sodium.crypto_scalarmult_ristretto255_base(v_scalar)
-    rH = sodium.crypto_scalarmult_ristretto255(r_scalar, H_POINT)
-    return sodium.crypto_core_ristretto255_add(vG, rH).hex()
 
 def pedersen_add(a_hex: str, b_hex: str) -> str:
     _require_point_hex(a_hex, "a_hex"); _require_point_hex(b_hex, "b_hex")
@@ -201,6 +169,33 @@ def _verify_bit_or_proof(C_hex: str, proof_tuple) -> bool:
     except Exception:
         return False
 
+def _verify_schnorr_H(D: bytes, proof_tuple, domain_prefix: bytes, subtract_challenge: bool = True) -> bool:
+    """
+    Generic Schnorr verifier over the fixed generator H.  Expects knowledge of r
+    such that D = r*H.  `proof_tuple` may be a tuple or list `(R, c, s)` of hex
+    strings.
+    """
+    try:
+        if not (isinstance(proof_tuple, (list, tuple)) and len(proof_tuple) == 3):
+            return False
+        R_hex, c_hex, s_hex = proof_tuple
+        _require_point_hex(R_hex, "R_hex")
+
+        R = bytes.fromhex(R_hex)
+        c = _scalar_from_hex(c_hex)
+        s = _scalar_from_hex(s_hex)
+
+        challenge = _hash_to_scalar(domain_prefix + D + R)
+        if c != challenge:
+            return False
+
+        lhs = _point_mul(H_POINT, s)
+        challenge_term = _point_mul(D, c)
+        rhs = _point_sub(R, challenge_term) if subtract_challenge else _point_add(R, challenge_term)
+        return lhs == rhs
+    except Exception:
+        return False
+
 def _verify_linkH_proof(D_hex: str, link_tuple) -> bool:
     """
     Knowledge of r: D = r*H
@@ -208,21 +203,30 @@ def _verify_linkH_proof(D_hex: str, link_tuple) -> bool:
     """
     try:
         _require_point_hex(D_hex, "D_hex")
-        if not (isinstance(link_tuple, tuple) and len(link_tuple) == 3):
-            return False
-        R_hex, c_hex, s_hex = link_tuple
-
         D = bytes.fromhex(D_hex)
-        R = bytes.fromhex(R_hex)
-        c = _scalar_from_hex(c_hex)
-        s = _scalar_from_hex(s_hex)
+        return _verify_schnorr_H(D, link_tuple, b"XIAN|linkH|")
+    except Exception:
+        return False
 
-        c_chk = _hash_to_scalar(b"XIAN|linkH|" + D + R)
-        if c != c_chk:
-            return False
-        lhs = _point_mul(H_POINT, s)
-        rhs = _point_sub(R, _point_mul(D, c))
-        return lhs == rhs
+
+def pedersen_same_value_proof_verify(commitment_a_hex: str, commitment_b_hex: str, proof_tuple) -> bool:
+    """
+    Verify a Schnorr proof that two commitments encode the same value.  The
+    prover demonstrates knowledge of r such that (A - B) = r*H, which can only
+    hold when both commitments share the same amount component.
+
+    `proof_tuple` may be a tuple or list of three 32-byte hex strings (R, c, s).
+    """
+    try:
+        _require_point_hex(commitment_a_hex, "commitment_a_hex")
+        _require_point_hex(commitment_b_hex, "commitment_b_hex")
+
+        A = bytes.fromhex(commitment_a_hex)
+        B = bytes.fromhex(commitment_b_hex)
+        D = _point_sub(A, B)
+        domain = b"XIAN|same_value|" + A + B
+
+        return _verify_schnorr_H(D, proof_tuple, domain)
     except Exception:
         return False
 
@@ -287,11 +291,11 @@ crypto_module = ModuleType('crypto')
 crypto_module.verify = verify
 crypto_module.key_is_valid = key_is_valid
 
-crypto_module.pedersen_commit = pedersen_commit
 crypto_module.pedersen_add = pedersen_add
 crypto_module.pedersen_sub = pedersen_sub
 crypto_module.pedersen_neg = pedersen_neg
 crypto_module.pedersen_eq = pedersen_eq
+crypto_module.pedersen_same_value_proof_verify = pedersen_same_value_proof_verify
 crypto_module.ristretto_is_canonical = ristretto_is_canonical
 
 crypto_module.range_proof_verify = range_proof_verify

--- a/src/contracting/stdlib/bridge/crypto.py
+++ b/src/contracting/stdlib/bridge/crypto.py
@@ -15,31 +15,28 @@ sodium.sodium_init()
 # ============================================================
 
 def verify(vk: str, msg: str, signature: str):
-    """
-    Ed25519 verify using PyNaCl.
-    vk: 32-byte hex public key
-    signature: 64-byte hex
-    msg: raw string (UTF-8 encoded here)
-    """
+    vk = bytes.fromhex(vk)
+    msg = msg.encode()
+    signature = bytes.fromhex(signature)
+
+    vk = nacl.signing.VerifyKey(vk)
     try:
-        vk_bytes = bytes.fromhex(vk)
-        sig_bytes = bytes.fromhex(signature)
-        msg_bytes = msg.encode('utf-8')
-        nacl.signing.VerifyKey(vk_bytes).verify(msg_bytes, sig_bytes)
-        return True
-    except Exception:
+        vk.verify(msg, signature)
+    except:
         return False
+    return True
 
 
 def key_is_valid(key: str):
-    """Check if hex string is exactly 32 bytes (64 hex chars)."""
-    if not isinstance(key, str) or len(key) != 64:
+    """ Check if the given address is valid.
+     Can be used with public and private keys """
+    if not len(key) == 64:
         return False
     try:
         int(key, 16)
-        return True
-    except Exception:
+    except:
         return False
+    return True
 
 
 # ============================================================

--- a/tests/integration/test_contracts/crypto_usage.s.py
+++ b/tests/integration/test_contracts/crypto_usage.s.py
@@ -1,0 +1,10 @@
+@export
+def commit(value: int, blinding: str):
+    # Mirror the stdlib bridge usage within a contract context.
+    return crypto.pedersen_commit(str(value), blinding)
+
+
+@export
+def verify_range(commitment: str, bit_commitments: list, bit_proofs: list, link_proof: list, bits: int):
+    # Accept either tuple or list for link proof and forward to the bridge module.
+    return crypto.range_proof_verify(commitment, bit_commitments, bit_proofs, tuple(link_proof), bits)

--- a/tests/integration/test_contracts/crypto_usage.s.py
+++ b/tests/integration/test_contracts/crypto_usage.s.py
@@ -1,6 +1,3 @@
 @export
 def verify_range(commitment: str, bit_commitments: list, bit_proofs: list, link_proof: list, bits: int):
-    # Normalise the iterable inputs so clients can submit JSON-friendly lists.
-    canonical_bit_proofs = [tuple(proof) for proof in bit_proofs]
-    canonical_link_proof = tuple(link_proof)
-    return crypto.range_proof_verify(commitment, bit_commitments, canonical_bit_proofs, canonical_link_proof, bits)
+    return crypto.range_proof_verify(commitment, bit_commitments, bit_proofs, link_proof, bits)

--- a/tests/integration/test_contracts/crypto_usage.s.py
+++ b/tests/integration/test_contracts/crypto_usage.s.py
@@ -1,10 +1,6 @@
 @export
-def commit(value: int, blinding: str):
-    # Mirror the stdlib bridge usage within a contract context.
-    return crypto.pedersen_commit(str(value), blinding)
-
-
-@export
 def verify_range(commitment: str, bit_commitments: list, bit_proofs: list, link_proof: list, bits: int):
-    # Accept either tuple or list for link proof and forward to the bridge module.
-    return crypto.range_proof_verify(commitment, bit_commitments, bit_proofs, tuple(link_proof), bits)
+    # Normalise the iterable inputs so clients can submit JSON-friendly lists.
+    canonical_bit_proofs = [tuple(proof) for proof in bit_proofs]
+    canonical_link_proof = tuple(link_proof)
+    return crypto.range_proof_verify(commitment, bit_commitments, canonical_bit_proofs, canonical_link_proof, bits)

--- a/tests/integration/test_crypto_contract_submission.py
+++ b/tests/integration/test_crypto_contract_submission.py
@@ -1,0 +1,67 @@
+from unittest import TestCase
+import os
+
+from contracting.storage.driver import Driver
+from contracting.execution.executor import Executor
+
+from tests.unit.test_crypto import make_range_proof
+
+
+SUBMISSION_CALL_KWARGS = {
+    'sender': 'stu',
+    'contract_name': 'submission',
+    'function_name': 'submit_contract',
+}
+
+
+def submission_payload_for(path: str):
+    base = os.path.basename(path)
+    name, *_ = base.split('.')
+    with open(path) as f:
+        code = f.read()
+    return {
+        'name': f'con_{name}',
+        'code': code,
+    }
+
+
+class TestCryptoContractSubmission(TestCase):
+    def setUp(self):
+        self.driver = Driver()
+        self.driver.flush_full()
+
+        submission_path = os.path.join(
+            os.path.dirname(__file__), 'test_contracts', 'submission.s.py'
+        )
+        with open(submission_path) as f:
+            submission_code = f.read()
+        self.driver.set_contract(name='submission', code=submission_code)
+        self.driver.commit()
+
+    def tearDown(self):
+        self.driver.flush_full()
+
+    def test_verify_range_accepts_valid_proof(self):
+        executor = Executor(metering=False)
+
+        contract_path = os.path.join(
+            os.path.dirname(__file__), 'test_contracts', 'crypto_usage.s.py'
+        )
+        executor.execute(
+            **SUBMISSION_CALL_KWARGS,
+            kwargs=submission_payload_for(contract_path),
+        )
+
+        commitment, bit_commitments, bit_proofs, link_proof = make_range_proof(173, bits=8)
+
+        payload = {
+            'commitment': commitment,
+            'bit_commitments': list(bit_commitments),
+            'bit_proofs': [list(proof) for proof in bit_proofs],
+            'link_proof': list(link_proof),
+            'bits': 8,
+        }
+
+        result = executor.execute('stu', 'con_crypto_usage', 'verify_range', kwargs=payload)
+
+        self.assertTrue(result['result'])

--- a/tests/integration/test_crypto_metering.py
+++ b/tests/integration/test_crypto_metering.py
@@ -1,0 +1,76 @@
+from unittest import TestCase
+from contracting.execution import runtime
+from contracting.stdlib import env
+from contracting.stdlib.bridge import crypto as C
+import copy
+
+from tests.unit.test_crypto import make_range_proof
+
+
+class TestCryptoContractMetering(TestCase):
+    def setUp(self):
+        scope = env.gather()
+        scope['__contract__'] = True
+
+        contract_source = """
+def commit(value, blinding):
+    return crypto.pedersen_commit(str(value), blinding)
+
+def verify_range(commitment, bit_commitments, bit_proofs, link_proof, bits):
+    return crypto.range_proof_verify(commitment, bit_commitments, bit_proofs, tuple(link_proof), bits)
+"""
+        exec(contract_source, scope)
+        self.scope = scope
+
+    def tearDown(self):
+        runtime.rt.clean_up()
+
+    def _run_metered(self, func, *args, **kwargs):
+        func.__globals__['__contract__'] = True
+        runtime.rt.set_up(stmps=1_000_000, meter=True)
+        try:
+            result = func(*args, **kwargs)
+            stamps = runtime.rt.tracer.get_stamp_used()
+            return result, stamps
+        finally:
+            runtime.rt.clean_up()
+
+    def test_pedersen_commit_is_deterministic_under_metering(self):
+        commit = self.scope['commit']
+
+        value = 1337
+        blinding = "11" * 32
+        expected = C.pedersen_commit(str(value), blinding)
+
+        first_result, first_stamps = self._run_metered(commit, value, blinding)
+        second_result, second_stamps = self._run_metered(commit, value, blinding)
+
+        self.assertEqual(first_result, expected)
+        self.assertEqual(second_result, expected)
+        self.assertEqual(first_result, second_result)
+        self.assertGreater(first_stamps, 0)
+        self.assertEqual(first_stamps, second_stamps)
+
+    def test_range_proof_verify_metering_is_stable(self):
+        verify_range = self.scope['verify_range']
+
+        bits = 8
+        value = 173
+        C_amt_hex, bit_cmts, bit_proofs, link_pf = make_range_proof(value, bits=bits)
+        self.assertTrue(C.range_proof_verify(C_amt_hex, bit_cmts, bit_proofs, link_pf, bits))
+
+        args = (
+            C_amt_hex,
+            list(bit_cmts),
+            copy.deepcopy(bit_proofs),
+            list(link_pf),
+            bits,
+        )
+
+        first_result, first_stamps = self._run_metered(verify_range, *args)
+        second_result, second_stamps = self._run_metered(verify_range, *args)
+
+        self.assertTrue(first_result)
+        self.assertTrue(second_result)
+        self.assertGreater(first_stamps, 0)
+        self.assertEqual(first_stamps, second_stamps)

--- a/tests/integration/test_crypto_metering.py
+++ b/tests/integration/test_crypto_metering.py
@@ -1,0 +1,138 @@
+from unittest import TestCase
+from contracting.execution import runtime
+from contracting.stdlib import env
+from contracting.stdlib.bridge import crypto as C
+import copy
+
+from tests.unit.test_crypto import (
+    make_range_proof,
+    make_same_value_proof,
+    pedersen_commit_for_tests,
+)
+
+
+class TestCryptoContractMetering(TestCase):
+    def setUp(self):
+        scope = env.gather()
+        scope['__contract__'] = True
+
+        contract_source = """
+def pedersen_add(a, b):
+    return crypto.pedersen_add(a, b)
+
+def pedersen_sub(a, b):
+    return crypto.pedersen_sub(a, b)
+
+def pedersen_neg(value):
+    return crypto.pedersen_neg(value)
+
+def pedersen_eq(a, b):
+    return crypto.pedersen_eq(a, b)
+
+def verify_range(commitment, bit_commitments, bit_proofs, link_proof, bits):
+    return crypto.range_proof_verify(commitment, bit_commitments, bit_proofs, tuple(link_proof), bits)
+
+def same_value(commitment_a, commitment_b, proof):
+    return crypto.pedersen_same_value_proof_verify(commitment_a, commitment_b, proof)
+"""
+        exec(contract_source, scope)
+        self.scope = scope
+
+    def tearDown(self):
+        runtime.rt.clean_up()
+
+    def _run_metered(self, func, *args, **kwargs):
+        func.__globals__['__contract__'] = True
+        runtime.rt.set_up(stmps=1_000_000, meter=True)
+        try:
+            result = func(*args, **kwargs)
+            stamps = runtime.rt.tracer.get_stamp_used()
+            return result, stamps
+        finally:
+            runtime.rt.clean_up()
+
+    def test_pedersen_group_ops_are_deterministic_under_metering(self):
+        pedersen_add = self.scope['pedersen_add']
+        pedersen_sub = self.scope['pedersen_sub']
+        pedersen_neg = self.scope['pedersen_neg']
+        pedersen_eq = self.scope['pedersen_eq']
+        same_value = self.scope['same_value']
+
+        v1 = "1337"
+        v2 = "4242"
+        r1 = "11" * 32
+        r2 = "22" * 32
+
+        c1 = pedersen_commit_for_tests(v1, r1)
+        c2 = pedersen_commit_for_tests(v2, r2)
+
+        expected_sum = C.pedersen_add(c1, c2)
+        expected_diff = C.pedersen_sub(c1, c2)
+        expected_neg = C.pedersen_neg(c1)
+
+        add_result, add_stamps = self._run_metered(pedersen_add, c1, c2)
+        add_again, add_stamps_again = self._run_metered(pedersen_add, c1, c2)
+        self.assertEqual(add_result, expected_sum)
+        self.assertEqual(add_again, expected_sum)
+        self.assertGreater(add_stamps, 0)
+        self.assertEqual(add_stamps, add_stamps_again)
+
+        sub_result, sub_stamps = self._run_metered(pedersen_sub, c1, c2)
+        sub_again, sub_stamps_again = self._run_metered(pedersen_sub, c1, c2)
+        self.assertEqual(sub_result, expected_diff)
+        self.assertEqual(sub_again, expected_diff)
+        self.assertGreater(sub_stamps, 0)
+        self.assertEqual(sub_stamps, sub_stamps_again)
+
+        neg_result, neg_stamps = self._run_metered(pedersen_neg, c1)
+        neg_again, neg_stamps_again = self._run_metered(pedersen_neg, c1)
+        self.assertEqual(neg_result, expected_neg)
+        self.assertEqual(neg_again, expected_neg)
+        self.assertGreater(neg_stamps, 0)
+        self.assertEqual(neg_stamps, neg_stamps_again)
+
+        eq_result, eq_stamps = self._run_metered(pedersen_eq, c1, expected_sum)
+        eq_again, eq_stamps_again = self._run_metered(pedersen_eq, c1, expected_sum)
+        self.assertFalse(eq_result)
+        self.assertFalse(eq_again)
+        self.assertGreater(eq_stamps, 0)
+        self.assertEqual(eq_stamps, eq_stamps_again)
+
+        eq_true, eq_true_stamps = self._run_metered(pedersen_eq, c1, c1)
+        eq_true_again, eq_true_stamps_again = self._run_metered(pedersen_eq, c1, c1)
+        self.assertTrue(eq_true)
+        self.assertTrue(eq_true_again)
+        self.assertGreater(eq_true_stamps, 0)
+        self.assertEqual(eq_true_stamps, eq_true_stamps_again)
+
+        C_same_a, C_same_b, proof = make_same_value_proof(99)
+        sv_result, sv_stamps = self._run_metered(same_value, C_same_a, C_same_b, proof)
+        sv_again, sv_stamps_again = self._run_metered(same_value, C_same_a, C_same_b, proof)
+        self.assertTrue(sv_result)
+        self.assertTrue(sv_again)
+        self.assertGreater(sv_stamps, 0)
+        self.assertEqual(sv_stamps, sv_stamps_again)
+
+    def test_range_proof_verify_metering_is_stable(self):
+        verify_range = self.scope['verify_range']
+
+        bits = 8
+        value = 173
+        C_amt_hex, bit_cmts, bit_proofs, link_pf = make_range_proof(value, bits=bits)
+        self.assertTrue(C.range_proof_verify(C_amt_hex, bit_cmts, bit_proofs, link_pf, bits))
+
+        args = (
+            C_amt_hex,
+            list(bit_cmts),
+            copy.deepcopy(bit_proofs),
+            list(link_pf),
+            bits,
+        )
+
+        first_result, first_stamps = self._run_metered(verify_range, *args)
+        second_result, second_stamps = self._run_metered(verify_range, *args)
+
+        self.assertTrue(first_result)
+        self.assertTrue(second_result)
+        self.assertGreater(first_stamps, 0)
+        self.assertEqual(first_stamps, second_stamps)

--- a/tests/unit/test_crypto.py
+++ b/tests/unit/test_crypto.py
@@ -229,8 +229,6 @@ class TestCryptoModule(TestCase):
         self.assertFalse(C.verify(vk_hex, msg + "!", sig_hex))
 
     def test_pedersen_group_ops_with_locally_built_commitments(self):
-        self.assertFalse(hasattr(C, 'pedersen_commit'))
-
         v = "123456"
         r_hex = "11" * 32
         c1 = pedersen_commit_for_tests(v, r_hex)
@@ -241,12 +239,6 @@ class TestCryptoModule(TestCase):
         zero_blind = "33" * 32
         z1 = pedersen_commit_for_tests("0", zero_blind)
         z2 = pedersen_commit_for_tests("0", zero_blind)
-        self.assertEqual(z1, z2)
-
-        # Zero-value path should remain deterministic as well (exercise v_scalar == 0 branch)
-        zero_blind = "33" * 32
-        z1 = C.pedersen_commit("0", zero_blind)
-        z2 = C.pedersen_commit("0", zero_blind)
         self.assertEqual(z1, z2)
 
         # C + (-C) == identity (encoded point is canonical)

--- a/tests/unit/test_crypto.py
+++ b/tests/unit/test_crypto.py
@@ -1,30 +1,25 @@
 from unittest import TestCase
 import os
 import hashlib
-from nacl.bindings import (
-    crypto_core_ristretto255_from_hash,
-    crypto_core_ristretto255_scalar_reduce,
-    crypto_core_ristretto255_add,
-    crypto_core_ristretto255_sub,
-    crypto_scalarmult_ristretto255,
-    crypto_scalarmult_ristretto255_base,
-)
+import nacl.signing  # only for Ed25519 keygen/sign in tests
+import pysodium as sodium
 
+# module under test
 from contracting.stdlib.bridge import crypto as C
 
 
 # === Helpers (mirror the module’s internal derivations) ======================
 
 def _scalar_reduce_from_bytes(b: bytes) -> bytes:
-    return crypto_core_ristretto255_scalar_reduce(b)
+    return sodium.crypto_core_ristretto255_scalar_reduce(b)
 
 def _scalar_from_u128(v: int) -> bytes:
     return _scalar_reduce_from_bytes(v.to_bytes(64, "little"))
 
 # Fixed H generator (must match module)
 _H_HASH = hashlib.sha512(b"XIAN|crypto.pedersen|H").digest()
-H_POINT = crypto_core_ristretto255_from_hash(_H_HASH)  # bytes (32)
-G_POINT = crypto_scalarmult_ristretto255_base(_scalar_from_u128(1))
+H_POINT = sodium.crypto_core_ristretto255_from_hash(_H_HASH)  # bytes (32)
+G_POINT = sodium.crypto_scalarmult_ristretto255_base(_scalar_from_u128(1))
 
 def _r_scalar_from_blinding_hex(blind_hex: str) -> bytes:
     seed = bytes.fromhex(blind_hex)
@@ -32,13 +27,13 @@ def _r_scalar_from_blinding_hex(blind_hex: str) -> bytes:
     return _scalar_reduce_from_bytes(r64)
 
 def _point_add(A: bytes, B: bytes) -> bytes:
-    return crypto_core_ristretto255_add(A, B)
+    return sodium.crypto_core_ristretto255_add(A, B)
 
 def _point_sub(A: bytes, B: bytes) -> bytes:
-    return crypto_core_ristretto255_sub(A, B)
+    return sodium.crypto_core_ristretto255_sub(A, B)
 
 def _point_mul(P: bytes, s: bytes) -> bytes:
-    return crypto_scalarmult_ristretto255(s, P)
+    return sodium.crypto_scalarmult_ristretto255(s, P)
 
 def _hash_to_scalar(ctx: bytes) -> bytes:
     return _scalar_reduce_from_bytes(hashlib.sha512(ctx).digest())
@@ -52,58 +47,57 @@ def make_bit_commitment_and_proof(bit: int, r_hex: str):
     proof_tuple = (t0, t1, c0, s0, c1, s1) as hex strings.
     """
     assert bit in (0, 1)
-    # Commitment C_i = b*G + r*H
+    # Commitment C_i = b*G + r*H (use module under test)
     Ci_hex = C.pedersen_commit(str(bit), r_hex)  # 32B hex
     Ci = bytes.fromhex(Ci_hex)
     Ci_minus_G = _point_sub(Ci, G_POINT)
 
     r = _r_scalar_from_blinding_hex(r_hex)
 
-    # OR-proof: either Ci = r*H (b=0) or Ci - G = r*H (b=1)
-    # Construct via Fiat–Shamir with simulation of the false branch.
+    # Fiat–Shamir OR-proof:
+    #   either Ci = r*H (b=0)  OR  (Ci - G) = r*H (b=1)
 
     # Random nonce for the true branch
     k_true = _scalar_reduce_from_bytes(os.urandom(64))
-    # Random challenge for the false branch
+    # Random challenge for the simulated (false) branch
     c_false = _scalar_reduce_from_bytes(os.urandom(64))
 
     if bit == 0:
         # true statement: Ci = r*H
         t0 = _point_mul(H_POINT, k_true)
-        # simulate false branch on (Ci - G): choose random t1, then derive c_true
-        t1 = bytes.fromhex(C.pedersen_commit("0", os.urandom(32).hex()))  # arbitrary point, fine as random
-        # Compute Fiat–Shamir challenge over (Ci, Ci-G, t0, t1)
-        c = _hash_to_scalar(b"XIAN|bit_or|" + Ci + Ci_minus_G + t0 + t1)
-        # c = c0 + c1 -> c0 = c - c1
-        # false branch is index 1 -> c1 = c_false
-        # true branch c0:
-        #   s0 = k_true - c0 * r
-        #   s1 is random, but must satisfy equation; easiest is: pick s1 and define t1 = s1*H - c1*(Ci - G)
-        c1 = c_false
-        # now compute c0 = c - c1
-        # scalar subtraction: reduce by reusing module’s scalar ops through nacl.bindings is cumbersome here;
-        # we can re-reduce (Python XOR with group order is internal). Use helper: c0_bytes = (c - c1) mod L
-        # We don't have L, but crypto_core_ristretto255_scalar_sub exists only for Scalars; we don't have direct access.
-        # Workaround: reuse module's pedersen_neg/add? Simpler: call nacl.bindings scalar_sub through a tiny wrapper is unavailable here.
-        # So instead: precompute s1,t1 consistent so verifier holds with arbitrary c0 computed as (c - c1) via scalar reduction trick:
-        # We'll import scalar_sub via C? The module doesn't export it. We'll recompute using bindings:
-        from nacl.bindings import crypto_core_ristretto255_scalar_sub as _sc_sub, crypto_core_ristretto255_scalar_add as _sc_add, crypto_core_ristretto255_scalar_mul as _sc_mul
-        c0 = _sc_sub(c, c1)
-        s0 = _sc_sub(k_true, _sc_mul(c0, r))
-        # For the simulated branch pick s1 randomly and set t1 accordingly:
+        # simulate false on (Ci - G): choose s1 random, set t1 = s1*H - c1*(Ci - G)
         s1 = _scalar_reduce_from_bytes(os.urandom(64))
+        c1 = c_false
         t1 = _point_sub(_point_mul(H_POINT, s1), _point_mul(Ci_minus_G, c1))
-    else:
-        # bit == 1, true statement on (Ci - G) = r*H
-        t1 = _point_mul(H_POINT, k_true)
-        t0 = bytes.fromhex(C.pedersen_commit("0", os.urandom(32).hex()))
+
+        # Fiat–Shamir challenge
         c = _hash_to_scalar(b"XIAN|bit_or|" + Ci + Ci_minus_G + t0 + t1)
-        from nacl.bindings import crypto_core_ristretto255_scalar_sub as _sc_sub, crypto_core_ristretto255_scalar_mul as _sc_mul
-        c0 = c_false
-        c1 = _sc_sub(c, c0)
-        s1 = _sc_sub(k_true, _sc_mul(c1, r))
+
+        # c = c0 + c1  =>  c0 = c - c1
+        c0 = sodium.crypto_core_ristretto255_scalar_sub(c, c1)
+        # s0 = k_true - c0*r
+        s0 = sodium.crypto_core_ristretto255_scalar_sub(
+            k_true,
+            sodium.crypto_core_ristretto255_scalar_mul(c0, r),
+        )
+    else:
+        # true statement: (Ci - G) = r*H
+        t1 = _point_mul(H_POINT, k_true)
+        # simulate false on Ci: choose s0 random, set t0 = s0*H - c0*Ci
         s0 = _scalar_reduce_from_bytes(os.urandom(64))
+        c0 = c_false
         t0 = _point_sub(_point_mul(H_POINT, s0), _point_mul(Ci, c0))
+
+        # Fiat–Shamir
+        c = _hash_to_scalar(b"XIAN|bit_or|" + Ci + Ci_minus_G + t0 + t1)
+
+        # c = c0 + c1  =>  c1 = c - c0
+        c1 = sodium.crypto_core_ristretto255_scalar_sub(c, c0)
+        # s1 = k_true - c1*r
+        s1 = sodium.crypto_core_ristretto255_scalar_sub(
+            k_true,
+            sodium.crypto_core_ristretto255_scalar_mul(c1, r),
+        )
 
     proof_tuple = (t0.hex(), t1.hex(), c0.hex(), s0.hex(), c1.hex(), s1.hex())
     return Ci_hex, proof_tuple
@@ -118,12 +112,12 @@ def make_range_proof(amount_value: int, bits: int = 8):
       - link proof (R,c,s as 3-tuple hex)
     """
     assert 0 <= amount_value < (1 << bits)
-    # Blinding for amount
+    # Amount & blinding
     r_amt_hex = os.urandom(32).hex()
     C_amt_hex = C.pedersen_commit(str(amount_value), r_amt_hex)
     C_amt = bytes.fromhex(C_amt_hex)
 
-    # Bit decomposition
+    # Bits
     bit_commitments = []
     bit_proofs = []
     r_scalars = []
@@ -135,7 +129,7 @@ def make_range_proof(amount_value: int, bits: int = 8):
         bit_proofs.append(proof_i)
         r_scalars.append(_r_scalar_from_blinding_hex(r_i_hex))
 
-    # Compute D = C - Σ 2^i * Ci  ; and r_D = r_amt - Σ 2^i * r_i  (scalars)
+    # D = C - Σ 2^i * Ci
     S = None
     for i, Ci_hex in enumerate(bit_commitments):
         Ci = bytes.fromhex(Ci_hex)
@@ -144,26 +138,24 @@ def make_range_proof(amount_value: int, bits: int = 8):
         S = term if S is None else _point_add(S, term)
     D = _point_sub(C_amt, S)
 
+    # r_D = r_amt - Σ 2^i * r_i
     r_amt = _r_scalar_from_blinding_hex(r_amt_hex)
-    from nacl.bindings import crypto_core_ristretto255_scalar_add as _sc_add, crypto_core_ristretto255_scalar_sub as _sc_sub, crypto_core_ristretto255_scalar_mul as _sc_mul
     r_sum = None
     for i, r_i in enumerate(r_scalars):
         two_i = _scalar_from_u128(1 << i)
-        term = _sc_mul(two_i, r_i)
-        r_sum = term if r_sum is None else _sc_add(r_sum, term)
-    r_D = _sc_sub(r_amt, r_sum)
+        term = sodium.crypto_core_ristretto255_scalar_mul(two_i, r_i)
+        r_sum = term if r_sum is None else sodium.crypto_core_ristretto255_scalar_add(r_sum, term)
+    r_D = sodium.crypto_core_ristretto255_scalar_sub(r_amt, r_sum)
 
-    # Link-H Schnorr: prove D = r_D * H
+    # Link-H Schnorr: D = r_D * H
     k = _scalar_reduce_from_bytes(os.urandom(64))
     R = _point_mul(H_POINT, k)
     c = _hash_to_scalar(b"XIAN|linkH|" + D + R)
-    from nacl.bindings import crypto_core_ristretto255_scalar_mul as _sc_mul
-    s = _scalar_reduce_from_bytes( (int.from_bytes(k, "little") - int.from_bytes(_sc_mul(c, r_D), "little")).to_bytes(64, "little") )
-    # Better: s = k - c*r_D using scalar ops:
-    from nacl.bindings import crypto_core_ristretto255_scalar_sub as _sc_sub
-    s = _sc_sub(k, _sc_mul(c, r_D))
-
+    s = sodium.crypto_core_ristretto255_scalar_sub(
+        k, sodium.crypto_core_ristretto255_scalar_mul(c, r_D)
+    )
     link_proof = (R.hex(), c.hex(), s.hex())
+
     return C_amt_hex, bit_commitments, bit_proofs, link_proof
 
 
@@ -194,10 +186,9 @@ class TestCryptoModule(TestCase):
         c2 = C.pedersen_commit(v, r_hex)
         self.assertEqual(c1, c2)  # deterministic
 
-        # Basic ops: C + (-C) == identity
+        # C + (-C) == identity (encoded point is canonical)
         neg = C.pedersen_neg(c1)
         zero = C.pedersen_add(c1, neg)
-        # zero should be canonical point, and equals itself
         self.assertTrue(C.ristretto_is_canonical(zero))
         self.assertTrue(C.pedersen_eq(zero, zero))
 

--- a/tests/unit/test_crypto.py
+++ b/tests/unit/test_crypto.py
@@ -9,8 +9,7 @@ from nacl.bindings import (
     crypto_scalarmult_ristretto255,
     crypto_scalarmult_ristretto255_base,
 )
-# Import the module under test
-# Adjust the import if your test runner uses a different sys.path
+
 from contracting.stdlib.bridge import crypto as C
 
 

--- a/tests/unit/test_crypto.py
+++ b/tests/unit/test_crypto.py
@@ -186,6 +186,12 @@ class TestCryptoModule(TestCase):
         c2 = C.pedersen_commit(v, r_hex)
         self.assertEqual(c1, c2)  # deterministic
 
+        # Zero-value path should remain deterministic as well (exercise v_scalar == 0 branch)
+        zero_blind = "33" * 32
+        z1 = C.pedersen_commit("0", zero_blind)
+        z2 = C.pedersen_commit("0", zero_blind)
+        self.assertEqual(z1, z2)
+
         # C + (-C) == identity (encoded point is canonical)
         neg = C.pedersen_neg(c1)
         zero = C.pedersen_add(c1, neg)
@@ -211,8 +217,10 @@ class TestCryptoModule(TestCase):
         # Build a valid 8-bit proof for a small value
         value = 173  # 0b10101101
         C_amt_hex, bit_cmts, bit_proofs, link_pf = make_range_proof(value, bits=8)
-        ok = C.range_proof_verify(C_amt_hex, bit_cmts, bit_proofs, link_pf, 8)
-        self.assertTrue(ok)
+        ok1 = C.range_proof_verify(C_amt_hex, bit_cmts, bit_proofs, link_pf, 8)
+        ok2 = C.range_proof_verify(C_amt_hex, bit_cmts, bit_proofs, link_pf, 8)
+        self.assertTrue(ok1)
+        self.assertTrue(ok2)
 
     def test_range_proof_verify_rejects_tamper(self):
         value = 77

--- a/tests/unit/test_crypto.py
+++ b/tests/unit/test_crypto.py
@@ -75,8 +75,8 @@ def make_bit_commitment_and_proof(bit: int, r_hex: str):
 
         # c = c0 + c1  =>  c0 = c - c1
         c0 = sodium.crypto_core_ristretto255_scalar_sub(c, c1)
-        # s0 = k_true - c0*r
-        s0 = sodium.crypto_core_ristretto255_scalar_sub(
+        # s0 = k_true + c0*r  (verifier checks s0*H = t0 + c0*C)
+        s0 = sodium.crypto_core_ristretto255_scalar_add(
             k_true,
             sodium.crypto_core_ristretto255_scalar_mul(c0, r),
         )
@@ -93,8 +93,8 @@ def make_bit_commitment_and_proof(bit: int, r_hex: str):
 
         # c = c0 + c1  =>  c1 = c - c0
         c1 = sodium.crypto_core_ristretto255_scalar_sub(c, c0)
-        # s1 = k_true - c1*r
-        s1 = sodium.crypto_core_ristretto255_scalar_sub(
+        # s1 = k_true + c1*r  (verifier checks s1*H = t1 + c1*(C - G))
+        s1 = sodium.crypto_core_ristretto255_scalar_add(
             k_true,
             sodium.crypto_core_ristretto255_scalar_mul(c1, r),
         )

--- a/tests/unit/test_crypto.py
+++ b/tests/unit/test_crypto.py
@@ -271,6 +271,16 @@ class TestCryptoModule(TestCase):
         self.assertTrue(ok1)
         self.assertTrue(ok2)
 
+    def test_range_proof_verify_accepts_list_serialised_inputs(self):
+        value = 173
+        C_amt_hex, bit_cmts, bit_proofs, link_pf = make_range_proof(value, bits=8)
+
+        # Simulate JSON serialisation (tuples -> lists)
+        bit_proofs_lists = [list(p) for p in bit_proofs]
+        link_pf_list = list(link_pf)
+
+        self.assertTrue(C.range_proof_verify(C_amt_hex, bit_cmts, bit_proofs_lists, link_pf_list, 8))
+
     def test_range_proof_verify_rejects_tamper(self):
         value = 77
         C_amt_hex, bit_cmts, bit_proofs, link_pf = make_range_proof(value, bits=8)

--- a/tests/unit/test_crypto.py
+++ b/tests/unit/test_crypto.py
@@ -39,6 +39,26 @@ def _hash_to_scalar(ctx: bytes) -> bytes:
     return _scalar_reduce_from_bytes(hashlib.sha512(ctx).digest())
 
 
+def pedersen_commit_for_tests(value_u128: str, blinding_hex: str) -> str:
+    assert isinstance(value_u128, str) and value_u128.isdigit(), "value must be decimal string"
+    v_int = int(value_u128, 10)
+    assert 0 <= v_int <= (1 << 128) - 1, "value out of range"
+    assert isinstance(blinding_hex, str) and len(blinding_hex) == 64, "blinding must be 32-byte hex"
+    _ = int(blinding_hex, 16)  # raises if non-hex
+
+    v_scalar = _scalar_from_u128(v_int)
+    r_seed = bytes.fromhex(blinding_hex)
+    r64 = hashlib.sha512(b"XIAN|crypto.pedersen|r|" + r_seed).digest()
+    r_scalar = _scalar_reduce_from_bytes(r64)
+
+    if v_scalar == bytes(32):
+        vG = _point_sub(H_POINT, H_POINT)
+    else:
+        vG = sodium.crypto_scalarmult_ristretto255_base(v_scalar)
+    rH = _point_mul(H_POINT, r_scalar)
+    return _point_add(vG, rH).hex()
+
+
 # === In-test prover for the Σ-protocol range proof ===========================
 
 def make_bit_commitment_and_proof(bit: int, r_hex: str):
@@ -48,7 +68,7 @@ def make_bit_commitment_and_proof(bit: int, r_hex: str):
     """
     assert bit in (0, 1)
     # Commitment C_i = b*G + r*H (use module under test)
-    Ci_hex = C.pedersen_commit(str(bit), r_hex)  # 32B hex
+    Ci_hex = pedersen_commit_for_tests(str(bit), r_hex)  # 32B hex
     Ci = bytes.fromhex(Ci_hex)
     Ci_minus_G = _point_sub(Ci, G_POINT)
 
@@ -114,7 +134,7 @@ def make_range_proof(amount_value: int, bits: int = 8):
     assert 0 <= amount_value < (1 << bits)
     # Amount & blinding
     r_amt_hex = os.urandom(32).hex()
-    C_amt_hex = C.pedersen_commit(str(amount_value), r_amt_hex)
+    C_amt_hex = pedersen_commit_for_tests(str(amount_value), r_amt_hex)
     C_amt = bytes.fromhex(C_amt_hex)
 
     # Bits
@@ -159,6 +179,35 @@ def make_range_proof(amount_value: int, bits: int = 8):
     return C_amt_hex, bit_commitments, bit_proofs, link_proof
 
 
+def make_same_value_proof(value: int):
+    """Return (commitment_a, commitment_b, proof_list)."""
+    assert isinstance(value, int) and value >= 0
+    r1_hex = os.urandom(32).hex()
+    r2_hex = os.urandom(32).hex()
+    C1_hex = pedersen_commit_for_tests(str(value), r1_hex)
+    C2_hex = pedersen_commit_for_tests(str(value), r2_hex)
+
+    C1 = bytes.fromhex(C1_hex)
+    C2 = bytes.fromhex(C2_hex)
+    D = _point_sub(C1, C2)
+
+    r1 = _r_scalar_from_blinding_hex(r1_hex)
+    r2 = _r_scalar_from_blinding_hex(r2_hex)
+    r_diff = sodium.crypto_core_ristretto255_scalar_sub(r1, r2)
+
+    k = _scalar_reduce_from_bytes(os.urandom(64))
+    R = _point_mul(H_POINT, k)
+    domain = b"XIAN|same_value|" + C1 + C2
+    c = _hash_to_scalar(domain + D + R)
+    s = sodium.crypto_core_ristretto255_scalar_sub(
+        k,
+        sodium.crypto_core_ristretto255_scalar_mul(c, r_diff),
+    )
+
+    proof_list = [R.hex(), c.hex(), s.hex()]
+    return C1_hex, C2_hex, proof_list
+
+
 # === Tests ===================================================================
 
 class TestCryptoModule(TestCase):
@@ -179,12 +228,20 @@ class TestCryptoModule(TestCase):
         self.assertTrue(C.verify(vk_hex, msg, sig_hex))
         self.assertFalse(C.verify(vk_hex, msg + "!", sig_hex))
 
-    def test_pedersen_commit_determinism_and_ops(self):
+    def test_pedersen_group_ops_with_locally_built_commitments(self):
+        self.assertFalse(hasattr(C, 'pedersen_commit'))
+
         v = "123456"
         r_hex = "11" * 32
-        c1 = C.pedersen_commit(v, r_hex)
-        c2 = C.pedersen_commit(v, r_hex)
-        self.assertEqual(c1, c2)  # deterministic
+        c1 = pedersen_commit_for_tests(v, r_hex)
+        c2 = pedersen_commit_for_tests(v, r_hex)
+        self.assertEqual(c1, c2)  # deterministic even when built locally
+
+        # Zero-value path should remain deterministic as well (exercise v_scalar == 0 branch)
+        zero_blind = "33" * 32
+        z1 = pedersen_commit_for_tests("0", zero_blind)
+        z2 = pedersen_commit_for_tests("0", zero_blind)
+        self.assertEqual(z1, z2)
 
         # C + (-C) == identity (encoded point is canonical)
         neg = C.pedersen_neg(c1)
@@ -194,13 +251,13 @@ class TestCryptoModule(TestCase):
 
         # Add/sub roundtrip
         r2_hex = "22" * 32
-        d = C.pedersen_commit("1", r2_hex)
+        d = pedersen_commit_for_tests("1", r2_hex)
         rtrip = C.pedersen_sub(C.pedersen_add(c1, d), d)
         self.assertTrue(C.pedersen_eq(c1, rtrip))
 
     def test_ristretto_is_canonical(self):
         v = "0"; r_hex = "33" * 32
-        c = C.pedersen_commit(v, r_hex)
+        c = pedersen_commit_for_tests(v, r_hex)
         self.assertTrue(C.ristretto_is_canonical(c))
         # Break hex length
         self.assertFalse(C.ristretto_is_canonical(c[:-2]))
@@ -211,8 +268,10 @@ class TestCryptoModule(TestCase):
         # Build a valid 8-bit proof for a small value
         value = 173  # 0b10101101
         C_amt_hex, bit_cmts, bit_proofs, link_pf = make_range_proof(value, bits=8)
-        ok = C.range_proof_verify(C_amt_hex, bit_cmts, bit_proofs, link_pf, 8)
-        self.assertTrue(ok)
+        ok1 = C.range_proof_verify(C_amt_hex, bit_cmts, bit_proofs, link_pf, 8)
+        ok2 = C.range_proof_verify(C_amt_hex, bit_cmts, bit_proofs, link_pf, 8)
+        self.assertTrue(ok1)
+        self.assertTrue(ok2)
 
     def test_range_proof_verify_rejects_tamper(self):
         value = 77
@@ -238,3 +297,18 @@ class TestCryptoModule(TestCase):
         # Claim bits=16 with only 8 provided
         ok = C.range_proof_verify(C_amt_hex, bit_cmts, bit_proofs, link_pf, 16)
         self.assertFalse(ok)
+
+    def test_pedersen_same_value_proof_accepts_valid_proof(self):
+        C1_hex, C2_hex, proof = make_same_value_proof(42)
+        self.assertTrue(C.pedersen_same_value_proof_verify(C1_hex, C2_hex, proof))
+        # Repeat to ensure deterministic verification path and tuple backwards compatibility
+        self.assertTrue(C.pedersen_same_value_proof_verify(C1_hex, C2_hex, tuple(proof)))
+
+    def test_pedersen_same_value_proof_rejects_tamper(self):
+        C1_hex, C2_hex, proof = make_same_value_proof(7)
+        bad_R = ("00" * 32)
+        tampered = [bad_R, proof[1], proof[2]]
+        self.assertFalse(C.pedersen_same_value_proof_verify(C1_hex, C2_hex, tampered))
+
+        bad_commit = C.pedersen_add(C1_hex, C2_hex)
+        self.assertFalse(C.pedersen_same_value_proof_verify(bad_commit, C2_hex, proof))

--- a/tests/unit/test_crypto.py
+++ b/tests/unit/test_crypto.py
@@ -1,0 +1,250 @@
+from unittest import TestCase
+import os
+import hashlib
+from nacl.bindings import (
+    crypto_core_ristretto255_from_hash,
+    crypto_core_ristretto255_scalar_reduce,
+    crypto_core_ristretto255_add,
+    crypto_core_ristretto255_sub,
+    crypto_scalarmult_ristretto255,
+    crypto_scalarmult_ristretto255_base,
+)
+# Import the module under test
+# Adjust the import if your test runner uses a different sys.path
+from contracting.stdlib.bridge import crypto as C
+
+
+# === Helpers (mirror the module’s internal derivations) ======================
+
+def _scalar_reduce_from_bytes(b: bytes) -> bytes:
+    return crypto_core_ristretto255_scalar_reduce(b)
+
+def _scalar_from_u128(v: int) -> bytes:
+    return _scalar_reduce_from_bytes(v.to_bytes(64, "little"))
+
+# Fixed H generator (must match module)
+_H_HASH = hashlib.sha512(b"XIAN|crypto.pedersen|H").digest()
+H_POINT = crypto_core_ristretto255_from_hash(_H_HASH)  # bytes (32)
+G_POINT = crypto_scalarmult_ristretto255_base(_scalar_from_u128(1))
+
+def _r_scalar_from_blinding_hex(blind_hex: str) -> bytes:
+    seed = bytes.fromhex(blind_hex)
+    r64 = hashlib.sha512(b"XIAN|crypto.pedersen|r|" + seed).digest()
+    return _scalar_reduce_from_bytes(r64)
+
+def _point_add(A: bytes, B: bytes) -> bytes:
+    return crypto_core_ristretto255_add(A, B)
+
+def _point_sub(A: bytes, B: bytes) -> bytes:
+    return crypto_core_ristretto255_sub(A, B)
+
+def _point_mul(P: bytes, s: bytes) -> bytes:
+    return crypto_scalarmult_ristretto255(s, P)
+
+def _hash_to_scalar(ctx: bytes) -> bytes:
+    return _scalar_reduce_from_bytes(hashlib.sha512(ctx).digest())
+
+
+# === In-test prover for the Σ-protocol range proof ===========================
+
+def make_bit_commitment_and_proof(bit: int, r_hex: str):
+    """
+    Produce (C_i_hex, proof_tuple) for a single bit b∈{0,1} with blinding r.
+    proof_tuple = (t0, t1, c0, s0, c1, s1) as hex strings.
+    """
+    assert bit in (0, 1)
+    # Commitment C_i = b*G + r*H
+    Ci_hex = C.pedersen_commit(str(bit), r_hex)  # 32B hex
+    Ci = bytes.fromhex(Ci_hex)
+    Ci_minus_G = _point_sub(Ci, G_POINT)
+
+    r = _r_scalar_from_blinding_hex(r_hex)
+
+    # OR-proof: either Ci = r*H (b=0) or Ci - G = r*H (b=1)
+    # Construct via Fiat–Shamir with simulation of the false branch.
+
+    # Random nonce for the true branch
+    k_true = _scalar_reduce_from_bytes(os.urandom(64))
+    # Random challenge for the false branch
+    c_false = _scalar_reduce_from_bytes(os.urandom(64))
+
+    if bit == 0:
+        # true statement: Ci = r*H
+        t0 = _point_mul(H_POINT, k_true)
+        # simulate false branch on (Ci - G): choose random t1, then derive c_true
+        t1 = bytes.fromhex(C.pedersen_commit("0", os.urandom(32).hex()))  # arbitrary point, fine as random
+        # Compute Fiat–Shamir challenge over (Ci, Ci-G, t0, t1)
+        c = _hash_to_scalar(b"XIAN|bit_or|" + Ci + Ci_minus_G + t0 + t1)
+        # c = c0 + c1 -> c0 = c - c1
+        # false branch is index 1 -> c1 = c_false
+        # true branch c0:
+        #   s0 = k_true - c0 * r
+        #   s1 is random, but must satisfy equation; easiest is: pick s1 and define t1 = s1*H - c1*(Ci - G)
+        c1 = c_false
+        # now compute c0 = c - c1
+        # scalar subtraction: reduce by reusing module’s scalar ops through nacl.bindings is cumbersome here;
+        # we can re-reduce (Python XOR with group order is internal). Use helper: c0_bytes = (c - c1) mod L
+        # We don't have L, but crypto_core_ristretto255_scalar_sub exists only for Scalars; we don't have direct access.
+        # Workaround: reuse module's pedersen_neg/add? Simpler: call nacl.bindings scalar_sub through a tiny wrapper is unavailable here.
+        # So instead: precompute s1,t1 consistent so verifier holds with arbitrary c0 computed as (c - c1) via scalar reduction trick:
+        # We'll import scalar_sub via C? The module doesn't export it. We'll recompute using bindings:
+        from nacl.bindings import crypto_core_ristretto255_scalar_sub as _sc_sub, crypto_core_ristretto255_scalar_add as _sc_add, crypto_core_ristretto255_scalar_mul as _sc_mul
+        c0 = _sc_sub(c, c1)
+        s0 = _sc_sub(k_true, _sc_mul(c0, r))
+        # For the simulated branch pick s1 randomly and set t1 accordingly:
+        s1 = _scalar_reduce_from_bytes(os.urandom(64))
+        t1 = _point_sub(_point_mul(H_POINT, s1), _point_mul(Ci_minus_G, c1))
+    else:
+        # bit == 1, true statement on (Ci - G) = r*H
+        t1 = _point_mul(H_POINT, k_true)
+        t0 = bytes.fromhex(C.pedersen_commit("0", os.urandom(32).hex()))
+        c = _hash_to_scalar(b"XIAN|bit_or|" + Ci + Ci_minus_G + t0 + t1)
+        from nacl.bindings import crypto_core_ristretto255_scalar_sub as _sc_sub, crypto_core_ristretto255_scalar_mul as _sc_mul
+        c0 = c_false
+        c1 = _sc_sub(c, c0)
+        s1 = _sc_sub(k_true, _sc_mul(c1, r))
+        s0 = _scalar_reduce_from_bytes(os.urandom(64))
+        t0 = _point_sub(_point_mul(H_POINT, s0), _point_mul(Ci, c0))
+
+    proof_tuple = (t0.hex(), t1.hex(), c0.hex(), s0.hex(), c1.hex(), s1.hex())
+    return Ci_hex, proof_tuple
+
+
+def make_range_proof(amount_value: int, bits: int = 8):
+    """
+    Build:
+      - amount commitment C (hex)
+      - per-bit commitments Ci (hex list)
+      - per-bit proofs (6-tuple hex)
+      - link proof (R,c,s as 3-tuple hex)
+    """
+    assert 0 <= amount_value < (1 << bits)
+    # Blinding for amount
+    r_amt_hex = os.urandom(32).hex()
+    C_amt_hex = C.pedersen_commit(str(amount_value), r_amt_hex)
+    C_amt = bytes.fromhex(C_amt_hex)
+
+    # Bit decomposition
+    bit_commitments = []
+    bit_proofs = []
+    r_scalars = []
+    for i in range(bits):
+        b = (amount_value >> i) & 1
+        r_i_hex = os.urandom(32).hex()
+        Ci_hex, proof_i = make_bit_commitment_and_proof(b, r_i_hex)
+        bit_commitments.append(Ci_hex)
+        bit_proofs.append(proof_i)
+        r_scalars.append(_r_scalar_from_blinding_hex(r_i_hex))
+
+    # Compute D = C - Σ 2^i * Ci  ; and r_D = r_amt - Σ 2^i * r_i  (scalars)
+    S = None
+    for i, Ci_hex in enumerate(bit_commitments):
+        Ci = bytes.fromhex(Ci_hex)
+        two_i = _scalar_from_u128(1 << i)
+        term = _point_mul(Ci, two_i)
+        S = term if S is None else _point_add(S, term)
+    D = _point_sub(C_amt, S)
+
+    r_amt = _r_scalar_from_blinding_hex(r_amt_hex)
+    from nacl.bindings import crypto_core_ristretto255_scalar_add as _sc_add, crypto_core_ristretto255_scalar_sub as _sc_sub, crypto_core_ristretto255_scalar_mul as _sc_mul
+    r_sum = None
+    for i, r_i in enumerate(r_scalars):
+        two_i = _scalar_from_u128(1 << i)
+        term = _sc_mul(two_i, r_i)
+        r_sum = term if r_sum is None else _sc_add(r_sum, term)
+    r_D = _sc_sub(r_amt, r_sum)
+
+    # Link-H Schnorr: prove D = r_D * H
+    k = _scalar_reduce_from_bytes(os.urandom(64))
+    R = _point_mul(H_POINT, k)
+    c = _hash_to_scalar(b"XIAN|linkH|" + D + R)
+    from nacl.bindings import crypto_core_ristretto255_scalar_mul as _sc_mul
+    s = _scalar_reduce_from_bytes( (int.from_bytes(k, "little") - int.from_bytes(_sc_mul(c, r_D), "little")).to_bytes(64, "little") )
+    # Better: s = k - c*r_D using scalar ops:
+    from nacl.bindings import crypto_core_ristretto255_scalar_sub as _sc_sub
+    s = _sc_sub(k, _sc_mul(c, r_D))
+
+    link_proof = (R.hex(), c.hex(), s.hex())
+    return C_amt_hex, bit_commitments, bit_proofs, link_proof
+
+
+# === Tests ===================================================================
+
+class TestCryptoModule(TestCase):
+
+    def test_key_is_valid(self):
+        good = "00" * 32
+        bad1 = "0" * 63
+        bad2 = "zz" * 32
+        self.assertTrue(C.key_is_valid(good))
+        self.assertFalse(C.key_is_valid(bad1))
+        self.assertFalse(C.key_is_valid(bad2))
+
+    def test_verify_signatures(self):
+        sk = nacl.signing.SigningKey.generate()
+        vk_hex = sk.verify_key.encode().hex()
+        msg = "hello-xian"
+        sig_hex = sk.sign(msg.encode()).signature.hex()
+        self.assertTrue(C.verify(vk_hex, msg, sig_hex))
+        self.assertFalse(C.verify(vk_hex, msg + "!", sig_hex))
+
+    def test_pedersen_commit_determinism_and_ops(self):
+        v = "123456"
+        r_hex = "11" * 32
+        c1 = C.pedersen_commit(v, r_hex)
+        c2 = C.pedersen_commit(v, r_hex)
+        self.assertEqual(c1, c2)  # deterministic
+
+        # Basic ops: C + (-C) == identity
+        neg = C.pedersen_neg(c1)
+        zero = C.pedersen_add(c1, neg)
+        # zero should be canonical point, and equals itself
+        self.assertTrue(C.ristretto_is_canonical(zero))
+        self.assertTrue(C.pedersen_eq(zero, zero))
+
+        # Add/sub roundtrip
+        r2_hex = "22" * 32
+        d = C.pedersen_commit("1", r2_hex)
+        rtrip = C.pedersen_sub(C.pedersen_add(c1, d), d)
+        self.assertTrue(C.pedersen_eq(c1, rtrip))
+
+    def test_ristretto_is_canonical(self):
+        v = "0"; r_hex = "33" * 32
+        c = C.pedersen_commit(v, r_hex)
+        self.assertTrue(C.ristretto_is_canonical(c))
+        # Break hex length
+        self.assertFalse(C.ristretto_is_canonical(c[:-2]))
+        # Non-hex
+        self.assertFalse(C.ristretto_is_canonical("x" * 64))
+
+    def test_range_proof_verify_positive_8bit(self):
+        # Build a valid 8-bit proof for a small value
+        value = 173  # 0b10101101
+        C_amt_hex, bit_cmts, bit_proofs, link_pf = make_range_proof(value, bits=8)
+        ok = C.range_proof_verify(C_amt_hex, bit_cmts, bit_proofs, link_pf, 8)
+        self.assertTrue(ok)
+
+    def test_range_proof_verify_rejects_tamper(self):
+        value = 77
+        C_amt_hex, bit_cmts, bit_proofs, link_pf = make_range_proof(value, bits=8)
+        # Tamper one bit commitment
+        bad_cmts = list(bit_cmts)
+        bad_cmts[3] = bad_cmts[3][:-2] + ("00" if bad_cmts[3][-2:] != "00" else "01")
+        ok = C.range_proof_verify(C_amt_hex, bad_cmts, bit_proofs, link_pf, 8)
+        self.assertFalse(ok)
+
+    def test_range_proof_verify_wrong_bits_len(self):
+        value = 12
+        C_amt_hex, bit_cmts, bit_proofs, link_pf = make_range_proof(value, bits=8)
+        # Drop a proof
+        ok = C.range_proof_verify(C_amt_hex, bit_cmts[:-1], bit_proofs, link_pf, 8)
+        self.assertFalse(ok)
+        ok = C.range_proof_verify(C_amt_hex, bit_cmts, bit_proofs[:-1], link_pf, 8)
+        self.assertFalse(ok)
+
+    def test_range_proof_verify_wrong_bits_param(self):
+        value = 5
+        C_amt_hex, bit_cmts, bit_proofs, link_pf = make_range_proof(value, bits=8)
+        # Claim bits=16 with only 8 provided
+        ok = C.range_proof_verify(C_amt_hex, bit_cmts, bit_proofs, link_pf, 16)
+        self.assertFalse(ok)


### PR DESCRIPTION
Description Summary

- Implement a Python-side crypto bridge using libsodium/pysodium to support Ristretto255-based Pedersen commitments and verification primitives.
- Add verification routines for per-bit OR-proofs, a link Schnorr proof (link-to-H), and a same-value Schnorr proof.
- Add comprehensive unit and integration tests and a small on-chain contract example exercising the API.
- Add pysodium to project dependencies and document the libsodium system dependency in the README.

What changed (high level)

New/updated implementation:

- `src/contracting/stdlib/bridge/crypto.py` — new Ristretto/Pedersen primitives and proof verifiers

Tests:

- `tests/unit/test_crypto.py` — exhaustive unit tests and helpers (local commitment/prover implementations used by tests).
- `tests/integration/test_crypto_metering.py` — checks metering stability and deterministic results under the runtime tracer.
- `tests/integration/test_crypto_contract_submission.py` — end-to-end submission/contract test using the executor.
- `tests/integration/test_contracts/crypto_usage.s.py` — contract wrapper for normalising JSON-friendly inputs and calling crypto.range_proof_verify.


New API (exports)

- crypto.pedersen_add(a_hex, b_hex)
- crypto.pedersen_sub(a_hex, b_hex)
- crypto.pedersen_neg(p_hex)
- crypto.pedersen_eq(a_hex, b_hex)
- crypto.ristretto_is_canonical(point_hex)
- crypto.pedersen_same_value_proof_verify(commitment_a_hex, commitment_b_hex, proof_list)
- crypto.range_proof_verify(amount_commitment_hex, bit_commitments_hex, bit_proofs, link_proof_list, bits)


Requires pysodium Python package (added to pyproject.toml).
Requires libsodium shared library on the host. The README now documents installing libsodium-dev on Debian/Ubuntu.
All new crypto helpers accept hex-encoded 32-byte values and perform input validation. Invalid/ malformed inputs return False rather than raising, making them safe for contract usage.
No signing keys or private material are exposed by the bridge — only verification and proof checking are implemented in the module.
