### PR TITLE
Allow crypto range proof verification to accept list inputs

### DIFF
--- a/src/contracting/stdlib/bridge/crypto.py
+++ b/src/contracting/stdlib/bridge/crypto.py
@@ -114,9 +114,9 @@ G_POINT = sodium.crypto_scalarmult_ristretto255_base(_scalar_one())  # bytes (ba
 
 # ============================================================
 # Python-only range proof verification (Σ-protocol)
-#   - Inputs: hex strings and tuples only (no JSON)
-#   - bit_proof: tuple(str,str,str,str,str,str) = (t0,t1,c0,s0,c1,s1)
-#   - link_proof: tuple(str,str,str) = (R,c,s)
+#   - Inputs: hex strings and tuple/list containers (JSON-friendly)
+#   - bit_proof: sequence[str] len==6  (t0,t1,c0,s0,c1,s1)
+#   - link_proof: sequence[str] len==3 (R,c,s)
 # ============================================================
 
 _ALLOWED_BITS = {8, 16, 32, 64}
@@ -141,9 +141,9 @@ def _verify_bit_or_proof(C_hex: str, proof_tuple) -> bool:
     """
     try:
         _require_point_hex(C_hex, "C_hex")
-        if not (isinstance(proof_tuple, tuple) and len(proof_tuple) == 6):
+        if not (isinstance(proof_tuple, (list, tuple)) and len(proof_tuple) == 6):
             return False
-        t0_hex, t1_hex, c0_hex, s0_hex, c1_hex, s1_hex = proof_tuple
+        t0_hex, t1_hex, c0_hex, s0_hex, c1_hex, s1_hex = tuple(proof_tuple)
 
         C = bytes.fromhex(C_hex)
         C_minus_G = _point_sub(C, G_POINT)

--- a/tests/unit/test_crypto.py
+++ b/tests/unit/test_crypto.py
@@ -271,6 +271,16 @@ class TestCryptoModule(TestCase):
         self.assertTrue(ok1)
         self.assertTrue(ok2)
 
+    def test_range_proof_verify_accepts_list_serialised_inputs(self):
+        value = 173
+        C_amt_hex, bit_cmts, bit_proofs, link_pf = make_range_proof(value, bits=8)
+
+        # Simulate JSON serialisation (tuples -> lists)
+        bit_proofs_lists = [list(p) for p in bit_proofs]
+        link_pf_list = list(link_pf)
+
+        self.assertTrue(C.range_proof_verify(C_amt_hex, bit_cmts, bit_proofs_lists, link_pf_list, 8))
+
     def test_range_proof_verify_rejects_tamper(self):
         value = 77
         C_amt_hex, bit_cmts, bit_proofs, link_pf = make_range_proof(value, bits=8)


### PR DESCRIPTION
## Summary
- allow the crypto range proof verifier to accept list or tuple encoded bit proofs
- update the inline documentation to reflect JSON-friendly inputs
- add a unit test covering list-serialised range proof verification inputs

## Testing
- pytest tests/unit/test_crypto.py *(fails: ModuleNotFoundError: No module named 'pysodium')*


------
https://chatgpt.com/codex/tasks/task_e_6905d13a32a48320a43043a1f531252e