### PR TITLE
Normalize range proof verification inputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,12 +10,13 @@ repository = "https://github.com/xian-network/xian-contracting"
 keywords = ["blockchain", "xian", "contracting", "python"]
 classifiers = [
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Development Status :: 5 - Production/Stable",
 ]
 
 [tool.poetry.dependencies]
-python = "~=3.11.0"
+python = ">=3.11,<3.13"
 astor = "0.8.1"
 pycodestyle = "2.10.0"
 autopep8 = "1.5.7"

--- a/src/contracting/stdlib/bridge/crypto.py
+++ b/src/contracting/stdlib/bridge/crypto.py
@@ -247,6 +247,13 @@ def range_proof_verify(amount_commitment_hex: str,
         if len(bit_commitments_hex) != len(bit_proofs) or len(bit_commitments_hex) != bits:
             return False
 
+        # Normalise iterables so callers may supply JSON-friendly lists.
+        try:
+            canonical_bit_proofs = [tuple(proof) for proof in bit_proofs]
+            canonical_link_proof = tuple(link_proof_tuple)
+        except TypeError:
+            return False
+
         _require_point_hex(amount_commitment_hex, "amount_commitment_hex")
         C = bytes.fromhex(amount_commitment_hex)
 
@@ -255,7 +262,7 @@ def range_proof_verify(amount_commitment_hex: str,
         for i in range(bits):
             Ci_hex = bit_commitments_hex[i]
             _require_point_hex(Ci_hex, f"bit_commitments_hex[{i}]")
-            if not _verify_bit_or_proof(Ci_hex, bit_proofs[i]):
+            if not _verify_bit_or_proof(Ci_hex, canonical_bit_proofs[i]):
                 return False
             Ci_bytes.append(bytes.fromhex(Ci_hex))
 
@@ -270,7 +277,7 @@ def range_proof_verify(amount_commitment_hex: str,
         D = _point_sub(C, S)
 
         # 4) prove D is H-multiple
-        if not _verify_linkH_proof(D.hex(), link_proof_tuple):
+        if not _verify_linkH_proof(D.hex(), canonical_link_proof):
             return False
 
         return True

--- a/tests/integration/test_contracts/crypto_usage.s.py
+++ b/tests/integration/test_contracts/crypto_usage.s.py
@@ -1,6 +1,3 @@
 @export
 def verify_range(commitment: str, bit_commitments: list, bit_proofs: list, link_proof: list, bits: int):
-    # Normalise the iterable inputs so clients can submit JSON-friendly lists.
-    canonical_bit_proofs = [tuple(proof) for proof in bit_proofs]
-    canonical_link_proof = tuple(link_proof)
-    return crypto.range_proof_verify(commitment, bit_commitments, canonical_bit_proofs, canonical_link_proof, bits)
+    return crypto.range_proof_verify(commitment, bit_commitments, bit_proofs, link_proof, bits)


### PR DESCRIPTION
## Summary
- normalize `crypto.range_proof_verify` inputs so callers can pass JSON-friendly lists
- simplify the integration contract that proxies the verifier
- relax the package's supported Python versions to include 3.12

## Testing
- pytest tests/unit/test_crypto.py tests/integration/test_crypto_metering.py

------
https://chatgpt.com/codex/tasks/task_e_6905d5d8840483209bc2ed5be13d6ca2