### PR TITLE
fix: raise StorageDecodeError on JSON decode failure instead of returning None (closes #142)

### DIFF
--- a/src/contracting/storage/encoder.py
+++ b/src/contracting/storage/encoder.py
@@ -119,6 +119,11 @@ def as_object(d):
     return dict(d)
 
 
+class StorageDecodeError(Exception):
+    """Raised when stored data cannot be decoded from JSON."""
+    pass
+
+
 # Decode has a hook for JSON objects, which are just Python dictionaries. You have to specify the logic in this hook.
 # This is not uniform, but this is how Python made it.
 def decode(data):
@@ -126,6 +131,15 @@ def decode(data):
         return None
 
     if isinstance(data, bytes):
+        data = data.decode()
+
+    try:
+        return json.loads(data, object_hook=as_object)
+    except json.decoder.JSONDecodeError as e:
+        raise StorageDecodeError(
+            f"Failed to decode stored value. Data repr: {safe_repr(data)}. Error: {e}"
+        ) from e
+s):
         data = data.decode()
 
     try:


### PR DESCRIPTION
## What
`encoder.decode()` silently catches `JSONDecodeError` and returns `None`, masking storage corruption. This causes callers to treat corrupt data as a missing key, potentially defaulting and caching derived (invalid) state.

## Fix
- Introduce a `StorageDecodeError` exception class.
- Replace the `except json.decoder.JSONDecodeError: return None` block with a `raise StorageDecodeError(...)` that includes a safe representation of the corrupted data and the original error message.
- This surfaces decode failures immediately to callers, preventing silent data corruption from propagating.

Closes #142