### PR TITLE
fix: return defensive copies for mutable types in Variable.get (closes #139)

### DIFF
--- a/src/contracting/storage/orm.py
+++ b/src/contracting/storage/orm.py
@@ -41,6 +41,8 @@ class Variable(Datum):
             if isinstance(dv, (list, dict)):
                 return deepcopy(dv)
             return dv
+        if isinstance(value, (list, dict)):
+            return deepcopy(value)
         return value
 
 class Hash(Datum):


### PR DESCRIPTION
## What
`Variable.get()` returns live references for mutable objects (dict/list) fetched from the driver. This allows in-place mutations by contract code to leak into the driver's cached/pending state, causing stale state across calls and transactions.

`Hash._get` already applies `deepcopy` for mutable types, but `Variable.get()` was missing this protection for the non-None return path.

## Fix
Added a `deepcopy` call in `Variable.get()` when the returned value is a `list` or `dict`, consistent with the existing pattern in `Hash._get`.

Closes #139